### PR TITLE
[FIX] Add support for p2sh-p2wsh transaction outputs

### DIFF
--- a/bitcoinlib/db.py
+++ b/bitcoinlib/db.py
@@ -294,7 +294,7 @@ class DbTransactionOutput(Base):
     spent = Column(Boolean(), default=False)
 
     __table_args__ = (CheckConstraint(script_type.in_(['', 'p2pkh',  'multisig', 'p2sh', 'pubkey', 'nulldata',
-                                                       'unknown', 'p2wpkh', 'p2wsh', 'p2sh_p2wpkh', 'p2sh_p2wpkh']),
+                                                       'unknown', 'p2wpkh', 'p2wsh', 'p2sh_p2wpkh', 'p2sh_p2wsh']),
                                       name='constraint_script_types_allowed'),)
 
 


### PR DESCRIPTION
There has probably been a typo in the `constraint_script_types_allowed` constraint of `TransactionOutput`, which prevented transactions with `p2sh_p2wsh` outputs from being saved properly.