### PR TITLE
Check network at Transaction.import_raw

### DIFF
--- a/bitcoinlib/services/bitcoind.py
+++ b/bitcoinlib/services/bitcoind.py
@@ -145,7 +145,7 @@ class BitcoindClient(BaseClient):
 
     def gettransaction(self, txid):
         tx = self.proxy.getrawtransaction(txid, 1)
-        t = Transaction.import_raw(tx['hex'])
+        t = Transaction.import_raw(tx['hex'], network=self.network)
         t.confirmations = tx['confirmations']
         if t.confirmations:
             t.status = 'confirmed'


### PR DESCRIPTION
This adds the network parameter to the Transaction.import_raw. 
Without this paramter, wrong addresses are returned when using the testnet.