### PR TITLE
Enable PostgreSQL and MySQL databases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,20 @@ matrix:
       language: sh
       python: "3.7"
       before_install:
-        - choco install python3
+        - choco install python --version=3.7.1
+        - choco install postgresql --params '/Password:postgres' --paramsglobal
         - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
         - python -m pip install --upgrade pip wheel
+
+before_install:
+  - sudo apt-get install -y postgresql postgresql-contrib
+  - sudo service postgresql start
 
 install:
   - pip install coveralls
   - pip install scrypt
+  - pip install psycopg2
+  - pip install parameterized
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,17 +29,22 @@ matrix:
       before_install:
         - choco install python --version=3.7.1
         - choco install postgresql --params '/Password:postgres' --paramsglobal
+        - choco install mysql
         - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
         - python -m pip install --upgrade pip wheel
 
 before_install:
   - sudo apt-get install -y postgresql postgresql-contrib
+  - sudo apt-get install -y mysql-server
   - sudo service postgresql start
+  - sudo service mysql start
 
 install:
   - pip install coveralls
   - pip install scrypt
   - pip install psycopg2
+  - pip install mysql-connector
+  - pip install mysqlclient
   - pip install parameterized
   - python setup.py install
 

--- a/bitcoinlib/config/config.py
+++ b/bitcoinlib/config/config.py
@@ -28,6 +28,9 @@ PY3 = sys.version_info[0] == 3
 TYPE_TEXT = str
 if not PY3:
     TYPE_TEXT = (str, unicode)
+TYPE_INT = int
+if not PY3:
+    TYPE_INT = (int, long)
 LOGLEVEL = 'WARNING'
 if PY3:
     import configparser

--- a/bitcoinlib/db.py
+++ b/bitcoinlib/db.py
@@ -46,7 +46,7 @@ class DbInit:
         if db_uri is None:
             sqlite_file = os.path.join(BCL_DATABASE_DIR, DEFAULT_DATABASE)
             db_uri = 'sqlite:///%s' % sqlite_file
-        self.engine = create_engine(db_uri)
+        self.engine = create_engine(db_uri, isolation_level='READ UNCOMMITTED')
         Session = sessionmaker(bind=self.engine)
 
         Base.metadata.create_all(self.engine)
@@ -114,7 +114,7 @@ class DbWallet(Base):
     id = Column(Integer, Sequence('wallet_id_seq'), primary_key=True)
     name = Column(String(80), unique=True)
     owner = Column(String(50))
-    network_name = Column(String, ForeignKey('networks.name'))
+    network_name = Column(String(20), ForeignKey('networks.name'))
     network = relationship("DbNetwork")
     purpose = Column(Integer)
     scheme = Column(String(25))
@@ -137,7 +137,7 @@ class DbWallet(Base):
     __table_args__ = (
         CheckConstraint(scheme.in_(['single', 'bip32']), name='constraint_allowed_schemes'),
         CheckConstraint(encoding.in_(['base58', 'bech32']), name='constraint_default_address_encodings_allowed'),
-        CheckConstraint(witness_type.in_(['legacy', 'segwit', 'p2sh-segwit']), name='constraint_allowed_types'),
+        CheckConstraint(witness_type.in_(['legacy', 'segwit', 'p2sh-segwit']), name='wallet_constraint_allowed_types'),
     )
 
     def __repr__(self):
@@ -172,8 +172,8 @@ class DbKey(Base):
     depth = Column(Integer)
     change = Column(Integer)
     address_index = Column(BigInteger)
-    public = Column(String(1024), index=True)
-    private = Column(String(1024), index=True)
+    public = Column(String(512), index=True)
+    private = Column(String(512), index=True)
     wif = Column(String(255), index=True)
     compressed = Column(Boolean, default=True)
     key_type = Column(String(10), default='bip32')
@@ -189,7 +189,7 @@ class DbKey(Base):
     transaction_outputs = relationship("DbTransactionOutput", cascade="all,delete", back_populates="key")
     balance = Column(Numeric(25, 0, asdecimal=False), default=0)
     used = Column(Boolean, default=False)
-    network_name = Column(String, ForeignKey('networks.name'))
+    network_name = Column(String(20), ForeignKey('networks.name'))
     network = relationship("DbNetwork")
     multisig_parents = relationship("DbKeyMultisigChildren", backref='child_key',
                                     primaryjoin=id == DbKeyMultisigChildren.child_id)
@@ -256,19 +256,19 @@ class DbTransaction(Base):
     fee = Column(Integer)
     inputs = relationship("DbTransactionInput", cascade="all,delete")
     outputs = relationship("DbTransactionOutput", cascade="all,delete")
-    status = Column(String, default='new')
+    status = Column(String(20), default='new')
     input_total = Column(Numeric(25, 0, asdecimal=False), default=0)
     output_total = Column(Numeric(25, 0, asdecimal=False), default=0)
-    network_name = Column(String, ForeignKey('networks.name'))
+    network_name = Column(String(20), ForeignKey('networks.name'))
     network = relationship("DbNetwork")
-    raw = Column(String)
+    raw = Column(String(1024))
     verified = Column(Boolean, default=False)
 
     __table_args__ = (
         UniqueConstraint('wallet_id', 'hash', name='constraint_wallet_transaction_hash_unique'),
         CheckConstraint(status.in_(['new', 'incomplete', 'unconfirmed', 'confirmed']),
                         name='constraint_status_allowed'),
-        CheckConstraint(witness_type.in_(['legacy', 'segwit']), name='constraint_allowed_types'),
+        CheckConstraint(witness_type.in_(['legacy', 'segwit']), name='transaction_constraint_allowed_types'),
     )
 
     def __repr__(self):
@@ -291,17 +291,17 @@ class DbTransactionInput(Base):
     witness_type = Column(String(20), default='legacy')
     prev_hash = Column(String(64))
     output_n = Column(BigInteger)
-    script = Column(String)
-    script_type = Column(String, default='sig_pubkey')
+    script = Column(String(1024))
+    script_type = Column(String(20), default='sig_pubkey')
     sequence = Column(Integer)
     value = Column(Numeric(25, 0, asdecimal=False), default=0)
     double_spend = Column(Boolean, default=False)
 
     __table_args__ = (CheckConstraint(script_type.in_(['', 'coinbase', 'sig_pubkey', 'p2sh_multisig',
                                                        'signature', 'unknown', 'p2sh_p2wpkh', 'p2sh_p2wsh']),
-                                      name='constraint_script_types_allowed'),
+                                      name='transactioninput_constraint_script_types_allowed'),
                       CheckConstraint(witness_type.in_(['legacy', 'segwit', 'p2sh-segwit']),
-                                      name='constraint_allowed_types'),)
+                                      name='transactioninput_constraint_allowed_types'),)
 
 
 class DbTransactionOutput(Base):
@@ -319,14 +319,14 @@ class DbTransactionOutput(Base):
     output_n = Column(BigInteger, primary_key=True)
     key_id = Column(Integer, ForeignKey('keys.id'), index=True)
     key = relationship("DbKey", back_populates="transaction_outputs")
-    script = Column(String)
-    script_type = Column(String, default='p2pkh')
+    script = Column(String(1024))
+    script_type = Column(String(20), default='p2pkh')
     value = Column(Numeric(25, 0, asdecimal=False), default=0)
     spent = Column(Boolean(), default=False)
 
     __table_args__ = (CheckConstraint(script_type.in_(['', 'p2pkh',  'multisig', 'p2sh', 'p2pk', 'nulldata',
                                                        'unknown', 'p2wpkh', 'p2wsh']),
-                                      name='constraint_script_types_allowed'),)
+                                      name='transactionoutput_constraint_script_types_allowed'),)
 
 
 if __name__ == '__main__':

--- a/bitcoinlib/services/bitcoind.py
+++ b/bitcoinlib/services/bitcoind.py
@@ -183,8 +183,8 @@ class BitcoindClient(BaseClient):
         if not (res['ismine'] or res['iswatchonly']):
             raise ClientError("Address %s not found in bitcoind wallet, use 'importaddress' to add address to "
                               "wallet." % address)
-            
-        for t in self.proxy.listunspent(0, 99999999, address):
+
+        for t in self.proxy.listunspent(0, 99999999, [address]):
             txs.append({
                 'address': t['address'],
                 'tx_hash': t['txid'],
@@ -207,7 +207,7 @@ class BitcoindClient(BaseClient):
             'txid': res,
             'response_dict': res
         }
-    
+
     def estimatefee(self, blocks):
         pres = ''
         try:

--- a/bitcoinlib/tools/cli_wallet.py
+++ b/bitcoinlib/tools/cli_wallet.py
@@ -75,7 +75,7 @@ def parse_args():
     group_wallet2.add_argument('--network', '-n',
                                help="Specify 'bitcoin', 'litecoin', 'testnet' or other supported network")
     group_wallet2.add_argument('--database', '-d',
-                               help="Name of specific database file to use",)
+                               help="URI of the database to use",)
     group_wallet2.add_argument('--create-from-key', '-c', metavar='KEY',
                                help="Create a new wallet from specified key")
     group_wallet2.add_argument('--create-multisig', '-m', nargs='*',
@@ -128,7 +128,7 @@ def get_passphrase(args):
     return passphrase
 
 
-def create_wallet(wallet_name, args, databasefile):
+def create_wallet(wallet_name, args, db_uri):
     if args.network is None:
         args.network = DEFAULT_NETWORK
     print("\nCREATE wallet '%s' (%s network)" % (wallet_name, args.network))
@@ -158,10 +158,10 @@ def create_wallet(wallet_name, args, databasefile):
                 seed = binascii.hexlify(Mnemonic().to_seed(passphrase))
                 key_list.append(HDKey.from_seed(seed, network=args.network))
         return HDWallet.create(wallet_name, key_list, sigs_required=sigs_required, network=args.network,
-                               databasefile=databasefile, witness_type=args.witness_type)
+                               db_uri=db_uri, witness_type=args.witness_type)
     elif args.create_from_key:
         return HDWallet.create(wallet_name, args.create_from_key, network=args.network,
-                               databasefile=databasefile, witness_type=args.witness_type)
+                               db_uri=db_uri, witness_type=args.witness_type)
     else:
         passphrase = args.passphrase
         if passphrase is None:
@@ -178,7 +178,7 @@ def create_wallet(wallet_name, args, databasefile):
         seed = binascii.hexlify(Mnemonic().to_seed(passphrase))
         hdkey = HDKey.from_seed(seed, network=args.network)
         return HDWallet.create(wallet_name, hdkey, network=args.network, witness_type=args.witness_type,
-                               databasefile=databasefile)
+                               db_uri=db_uri)
 
 
 def create_transaction(wlt, send_args, args):
@@ -221,9 +221,7 @@ def main():
     # --- Parse commandline arguments ---
     args = parse_args()
 
-    databasefile = DEFAULT_DATABASE
-    if args.database:
-        databasefile = os.path.join(BCL_DATABASE_DIR, args.database)
+    db_uri = args.database
 
     if args.generate_key:
         passphrase = get_passphrase(args)
@@ -240,7 +238,7 @@ def main():
     # List wallets, then exit
     if args.list_wallets:
         print("BitcoinLib wallets:")
-        for w in wallets_list(databasefile=databasefile):
+        for w in wallets_list(db_uri=db_uri):
             if 'parent_id' in w and w['parent_id']:
                 continue
             print("[%d] %s (%s) %s" % (w['id'], w['name'], w['network'], w['owner']))
@@ -248,12 +246,12 @@ def main():
 
     # Delete specified wallet, then exit
     if args.wallet_remove:
-        if not wallet_exists(args.wallet_name, databasefile=databasefile):
+        if not wallet_exists(args.wallet_name, db_uri=db_uri):
             clw_exit("Wallet '%s' not found" % args.wallet_name)
         inp = input("\nWallet '%s' with all keys and will be removed, without private key it cannot be restored."
                     "\nPlease retype exact name of wallet to proceed: " % args.wallet_name)
         if inp == args.wallet_name:
-            if wallet_delete(args.wallet_name, force=True, databasefile=databasefile):
+            if wallet_delete(args.wallet_name, force=True, db_uri=db_uri):
                 clw_exit("\nWallet %s has been removed" % args.wallet_name)
             else:
                 clw_exit("\nError when deleting wallet")
@@ -262,15 +260,15 @@ def main():
 
     wlt = None
     if args.wallet_name and not args.wallet_name.isdigit() and not wallet_exists(args.wallet_name,
-                                                                                 databasefile=databasefile):
+                                                                                 db_uri=db_uri):
         if not args.create_from_key and input(
                     "Wallet %s does not exist, create new wallet [yN]? " % args.wallet_name).lower() != 'y':
             clw_exit('Aborted')
-        wlt = create_wallet(args.wallet_name, args, databasefile)
+        wlt = create_wallet(args.wallet_name, args, db_uri)
         args.wallet_info = True
     else:
         try:
-            wlt = HDWallet(args.wallet_name, databasefile=databasefile)
+            wlt = HDWallet(args.wallet_name, db_uri=db_uri)
             if args.passphrase is not None:
                 print("WARNING: Using passphrase option for existing wallet ignored")
             if args.create_from_key is not None:

--- a/bitcoinlib/transactions.py
+++ b/bitcoinlib/transactions.py
@@ -1435,11 +1435,11 @@ class Transaction(object):
                 hash_sequence = double_sha256(sequence_serialized)
         if (hash_type & 0x1f) != SIGHASH_SINGLE and (hash_type & 0x1f) != SIGHASH_NONE:
             for o in self.outputs:
-                outputs_serialized += struct.pack('<Q', o.value)
+                outputs_serialized += struct.pack('<Q', int(o.value))
                 outputs_serialized += varstr(o.lock_script)
             hash_outputs = double_sha256(outputs_serialized)
         elif (hash_type & 0x1f) != SIGHASH_SINGLE and sign_id < len(self.outputs):
-            outputs_serialized += struct.pack('<Q', self.outputs[sign_id].value)
+            outputs_serialized += struct.pack('<Q', int(self.outputs[sign_id].value))
             outputs_serialized += varstr(self.outputs[sign_id].lock_script)
             hash_outputs = double_sha256(outputs_serialized)
 
@@ -1457,7 +1457,7 @@ class Transaction(object):
         ser_tx = \
             self.version[::-1] + hash_prevouts + hash_sequence + self.inputs[sign_id].prev_hash[::-1] + \
             self.inputs[sign_id].output_n[::-1] + \
-            varstr(script_code) + struct.pack('<Q', self.inputs[sign_id].value) + \
+            varstr(script_code) + struct.pack('<Q', int(self.inputs[sign_id].value)) + \
             struct.pack('<L', self.inputs[sign_id].sequence) + \
             hash_outputs + struct.pack('<L', self.locktime) + struct.pack('<L', hash_type)
         # print(to_hexstring(ser_tx))
@@ -1508,7 +1508,7 @@ class Transaction(object):
         for o in self.outputs:
             if o.value < 0:
                 raise TransactionError("Output value < 0 not allowed")
-            r += struct.pack('<Q', o.value)
+            r += struct.pack('<Q', int(o.value))
             r += varstr(o.lock_script)
 
         if sign_id is None and witness_type == 'segwit':

--- a/bitcoinlib/wallets.py
+++ b/bitcoinlib/wallets.py
@@ -17,22 +17,22 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import json
 import numbers
 import random
 import warnings
-from sqlalchemy import or_, func
 from itertools import groupby
 from operator import itemgetter
-import json
 
 from bitcoinlib.db import *
-from bitcoinlib.encoding import to_hexstring, to_bytes, EncodingError
-from bitcoinlib.keys import HDKey, check_network_and_key, Address, path_expand, BKeyError
+from bitcoinlib.encoding import EncodingError, to_bytes, to_hexstring
+from bitcoinlib.keys import Address, BKeyError, HDKey, check_network_and_key, path_expand
+from bitcoinlib.mnemonic import Mnemonic
 from bitcoinlib.networks import Network
 from bitcoinlib.services.services import Service
-from bitcoinlib.mnemonic import Mnemonic
-from bitcoinlib.transactions import Transaction, serialize_multisig_redeemscript, Output, Input, \
-    get_unlocking_script_type
+from bitcoinlib.transactions import (Input, Output, Transaction, get_unlocking_script_type,
+                                     serialize_multisig_redeemscript)
+from sqlalchemy import func, or_
 
 _logger = logging.getLogger(__name__)
 
@@ -50,20 +50,20 @@ class WalletError(Exception):
         return self.msg
 
 
-def wallets_list(databasefile=DEFAULT_DATABASE, include_cosigners=False):
+def wallets_list(db_uri=None, include_cosigners=False):
     """
     List Wallets from database
-    
-    :param databasefile: Location of Sqlite database. Leave empty to use default
-    :type databasefile: str
+
+    :param db_uri: URI of the database
+    :type db_uri: str
     :param include_cosigners: Child wallets for multisig wallets are for internal use only and are skipped by default
     :type include_cosigners: bool
-    
+
     :return dict: Dictionary of wallets defined in database
     """
 
-    session = DbInit(databasefile=databasefile).session
-    wallets = session.query(DbWallet).all()
+    session = DbInit(db_uri=db_uri).session
+    wallets = session.query(DbWallet).order_by(DbWallet.id).all()
     wlst = []
     for w in wallets:
         if w.parent_id and not include_cosigners:
@@ -82,21 +82,21 @@ def wallets_list(databasefile=DEFAULT_DATABASE, include_cosigners=False):
     return wlst
 
 
-def wallet_exists(wallet, databasefile=DEFAULT_DATABASE):
+def wallet_exists(wallet, db_uri=None):
     """
     Check if Wallets is defined in database
-    
+
     :param wallet: Wallet ID as integer or Wallet Name as string
     :type wallet: int, str
-    :param databasefile: Location of Sqlite database. Leave empty to use default
-    :type databasefile: str
-    
+    :param db_uri: URI of the database
+    :type db_uri: str
+
     :return bool: True if wallet exists otherwise False
     """
 
-    if wallet in [x['name'] for x in wallets_list(databasefile)]:
+    if wallet in [x['name'] for x in wallets_list(db_uri)]:
         return True
-    if isinstance(wallet, int) and wallet in [x['id'] for x in wallets_list(databasefile)]:
+    if isinstance(wallet, int) and wallet in [x['id'] for x in wallets_list(db_uri)]:
         return True
     return False
 
@@ -104,25 +104,25 @@ def wallet_exists(wallet, databasefile=DEFAULT_DATABASE):
 def wallet_create_or_open(
         name, keys='', owner='', network=None, account_id=0, purpose=None, scheme='bip32', sort_keys=True,
         password='', witness_type=None, encoding=None, multisig=None, sigs_required=None, cosigner_id=None,
-        key_path=None, databasefile=DEFAULT_DATABASE):
+        key_path=None, db_uri=None):
     """
     Create a wallet with specified options if it doesn't exist, otherwise just open
 
     See Wallets class create method for option documentation
     """
-    if wallet_exists(name, databasefile=databasefile):
-        return HDWallet(name, databasefile=databasefile)
+    if wallet_exists(name, db_uri=db_uri):
+        return HDWallet(name, db_uri=db_uri)
     else:
         return HDWallet.create(name, keys, owner, network, account_id, purpose, scheme, sort_keys,
                                password, witness_type, encoding, multisig, sigs_required, cosigner_id,
-                               key_path, databasefile=databasefile)
+                               key_path, db_uri=db_uri)
 
 
 @deprecated  # In version 0.4.5
 def wallet_create_or_open_multisig(
         name, keys, sigs_required=None, owner='', network=None, account_id=0, purpose=None, sort_keys=True,
         witness_type=DEFAULT_WITNESS_TYPE, encoding=None, cosigner_id=None, key_path=None,
-        databasefile=DEFAULT_DATABASE):  # pragma: no cover
+        db_uri=None):  # pragma: no cover
     """
     Deprecated since version 0.4.5, use wallet_create_or_open instead
 
@@ -132,30 +132,30 @@ def wallet_create_or_open_multisig(
     """
 
     warnings.warn("Deprecated since version 0.4.5, use wallet_create_or_open instead", DeprecationWarning)
-    if wallet_exists(name, databasefile=databasefile):
-        return HDWallet(name, databasefile=databasefile)
+    if wallet_exists(name, db_uri=db_uri):
+        return HDWallet(name, db_uri=db_uri)
     else:
         return HDWallet.create(name, keys, owner, network, account_id, purpose, 'bip32', sort_keys,
                                '', witness_type, encoding, True, sigs_required, cosigner_id,
-                               key_path, databasefile=databasefile)
+                               key_path, db_uri=db_uri)
 
 
-def wallet_delete(wallet, databasefile=DEFAULT_DATABASE, force=False):
+def wallet_delete(wallet, db_uri=None, force=False):
     """
     Delete wallet and associated keys and transactions from the database. If wallet has unspent outputs it raises a
     WalletError exception unless 'force=True' is specified
-    
+
     :param wallet: Wallet ID as integer or Wallet Name as string
     :type wallet: int, str
-    :param databasefile: Location of Sqlite database. Leave empty to use default
-    :type databasefile: str
+    :param db_uri: URI of the database
+    :type db_uri: str
     :param force: If set to True wallet will be deleted even if unspent outputs are found. Default is False
     :type force: bool
-    
+
     :return int: Number of rows deleted, so 1 if succesfull
     """
 
-    session = DbInit(databasefile=databasefile).session
+    session = DbInit(db_uri=db_uri).session
     if isinstance(wallet, int) or wallet.isdigit():
         w = session.query(DbWallet).filter_by(id=wallet)
     else:
@@ -164,6 +164,10 @@ def wallet_delete(wallet, databasefile=DEFAULT_DATABASE, force=False):
         session.close()
         raise WalletError("Wallet '%s' not found" % wallet)
     wallet_id = w.first().id
+
+    # Delete co-signer wallets if this is a multisig wallet
+    for cw in session.query(DbWallet).filter_by(parent_id=wallet_id).all():
+        wallet_delete(cw.id, db_uri=db_uri, force=force)
 
     # Delete keys from this wallet and update transactions (remove key_id)
     ks = session.query(DbKey).filter_by(wallet_id=wallet_id)
@@ -185,29 +189,25 @@ def wallet_delete(wallet, databasefile=DEFAULT_DATABASE, force=False):
     session.commit()
     session.close()
 
-    # Delete co-signer wallets if this is a multisig wallet
-    for cw in session.query(DbWallet).filter_by(parent_id=wallet_id).all():
-        wallet_delete(cw.id, databasefile=databasefile, force=force)
-
     _logger.info("Wallet '%s' deleted" % wallet)
 
     return res
 
 
-def wallet_empty(wallet, databasefile=DEFAULT_DATABASE):
+def wallet_empty(wallet, db_uri=None):
     """
     Remove all generated keys and transactions from wallet. Does not delete the wallet itself or the masterkey,
     so everything can be recreated.
 
     :param wallet: Wallet ID as integer or Wallet Name as string
     :type wallet: int, str
-    :param databasefile: Location of Sqlite database. Leave empty to use default
-    :type databasefile: str
+    :param db_uri: URI of the database
+    :type db_uri: str
 
     :return bool: True if successful
     """
 
-    session = DbInit(databasefile=databasefile).session
+    session = DbInit(db_uri=db_uri).session
     if isinstance(wallet, int) or wallet.isdigit():
         w = session.query(DbWallet).filter_by(id=wallet)
     else:
@@ -217,7 +217,7 @@ def wallet_empty(wallet, databasefile=DEFAULT_DATABASE):
     wallet_id = w.first().id
 
     # Delete keys from this wallet and update transactions (remove key_id)
-    ks = session.query(DbKey).filter(DbKey.wallet_id == wallet_id, DbKey.parent_id.isnot(0))
+    ks = session.query(DbKey).filter(DbKey.wallet_id == wallet_id, DbKey.parent_id != 0)
     for k in ks:
         session.query(DbTransactionOutput).filter_by(key_id=k.id).update({DbTransactionOutput.key_id: None})
         session.query(DbTransactionInput).filter_by(key_id=k.id).update({DbTransactionInput.key_id: None})
@@ -236,23 +236,23 @@ def wallet_empty(wallet, databasefile=DEFAULT_DATABASE):
     return True
 
 
-def wallet_delete_if_exists(wallet, databasefile=DEFAULT_DATABASE, force=False):
+def wallet_delete_if_exists(wallet, db_uri=None, force=False):
     """
     Delete wallet and associated keys from the database. If wallet has unspent outputs it raises a WalletError exception
     unless 'force=True' is specified. If wallet wallet does not exist return False
 
     :param wallet: Wallet ID as integer or Wallet Name as string
     :type wallet: int, str
-    :param databasefile: Location of Sqlite database. Leave empty to use default
-    :type databasefile: str
+    :param db_uri: URI of the database
+    :type db_uri: str
     :param force: If set to True wallet will be deleted even if unspent outputs are found. Default is False
     :type force: bool
 
-    :return int: Number of rows deleted, so 1 if succesfull
+    :return int: Number of rows deleted, so 1 if successful
     """
 
-    if wallet_exists(wallet, databasefile):
-        return wallet_delete(wallet, databasefile, force)
+    if wallet_exists(wallet, db_uri):
+        return wallet_delete(wallet, db_uri, force)
     return False
 
 
@@ -260,7 +260,7 @@ def normalize_path(path):
     """
     Normalize BIP0044 key path for HD keys. Using single quotes for hardened keys
 
-    :param path: BIP0044 key path 
+    :param path: BIP0044 key path
     :type path: str
 
     :return str: Normalized BIP0044 key path with single quotes
@@ -285,13 +285,13 @@ def parse_bip44_path(path):  # pragma: no cover
     """
     Assumes a correct BIP0044 path and returns a dictionary with path items. See Bitcoin improvement proposals
     BIP0043 and BIP0044.
-    
+
     Specify path in this format: m / purpose' / cointype' / account' / change / address_index.
     Path length must be between 1 and 6 (Depth between 0 and 5)
-    
-    :param path: BIP0044 path as string, with backslash (/) seperator. 
+
+    :param path: BIP0044 path as string, with backslash (/) seperator.
     :type path: str
-    
+
     :return dict: Dictionary with path items: is_private, purpose, cointype, account, change and address_index
     """
 
@@ -313,7 +313,7 @@ class HDWalletKey(object):
     """
     Normally only used as attribute of HDWallet class. Contains HDKey class, and adds extra information such as
     key ID, name, path and balance.
-    
+
     All HDWalletKey are stored in a database
     """
 
@@ -323,7 +323,7 @@ class HDWalletKey(object):
                  cosigner_id=None):
         """
         Create HDWalletKey from a HDKey object or key
-        
+
         :param name: New key name
         :type name: str
         :param wallet_id: ID of wallet where to store key
@@ -424,6 +424,7 @@ class HDWalletKey(object):
                        parent_id=parent_id, compressed=k.compressed, is_private=False, path=path,
                        key_type=key_type, network_name=network, encoding=encoding, cosigner_id=cosigner_id)
 
+        session.merge(DbNetwork(name=network))
         session.add(nk)
         session.commit()
         return HDWalletKey(nk.id, session, k)
@@ -431,7 +432,7 @@ class HDWalletKey(object):
     def __init__(self, key_id, session, hdkey_object=None):
         """
         Initialize HDWalletKey with specified ID, get information from database.
-        
+
         :param key_id: ID of key as mentioned in database
         :type key_id: int
         :param session: Required Sqlalchemy Session object
@@ -521,11 +522,11 @@ class HDWalletKey(object):
     def balance(self, fmt=''):
         """
         Get total value of unspent outputs
-        
+
         :param fmt: Specify 'string' to return a string in currency format
         :type fmt: str
-        
-        :return float, str: Key balance 
+
+        :return float, str: Key balance
         """
 
         if fmt == 'string':
@@ -893,25 +894,23 @@ class HDWalletTransaction(Transaction):
 
 class HDWallet(object):
     """
-    Class to create and manage keys Using the BIP0044 Hierarchical Deterministic wallet definitions, so you can 
+    Class to create and manage keys Using the BIP0044 Hierarchical Deterministic wallet definitions, so you can
     use one Masterkey to generate as much child keys as you want in a structured manner.
-    
+
     You can import keys in many format such as WIF or extended WIF, bytes, hexstring, seeds or private key integer.
     For the Bitcoin network, Litecoin or any other network you define in the settings.
-    
+
     Easily send and receive transactions. Compose transactions automatically or select unspent outputs.
-    
+
     Each wallet name must be unique and can contain only one cointype and purpose, but practically unlimited
-    accounts and addresses. 
+    accounts and addresses.
     """
 
     @classmethod
     def _create(cls, name, key, owner, network, account_id, purpose, scheme, parent_id, sort_keys,
-                witness_type, encoding, multisig, sigs_required, cosigner_id, key_path, databasefile):
+                witness_type, encoding, multisig, sigs_required, cosigner_id, key_path, db_uri):
 
-        if databasefile is None:
-            databasefile = DEFAULT_DATABASE
-        session = DbInit(databasefile=databasefile).session
+        session = DbInit(db_uri=db_uri).session
         if session.query(DbWallet).filter_by(name=name).count():
             raise WalletError("Wallet with name '%s' already exists" % name)
         else:
@@ -939,6 +938,7 @@ class HDWallet(object):
 
         if isinstance(key_path, list):
             key_path = '/'.join(key_path)
+        session.merge(DbNetwork(name=network))
         new_wallet = DbWallet(name=name, owner=owner, network_name=network, purpose=purpose, scheme=scheme,
                               sort_keys=sort_keys, witness_type=witness_type, parent_id=parent_id, encoding=encoding,
                               multisig=multisig, multisig_n_required=sigs_required, cosigner_id=cosigner_id,
@@ -948,7 +948,7 @@ class HDWallet(object):
         new_wallet_id = new_wallet.id
 
         if scheme == 'bip32' and multisig and parent_id is None:
-            w = cls(new_wallet_id, databasefile=databasefile)
+            w = cls(new_wallet_id, db_uri=db_uri)
         elif scheme == 'bip32':
             mk = HDWalletKey.from_key(key=key, name=name, session=session, wallet_id=new_wallet_id, network=network,
                                       account_id=account_id, purpose=purpose, key_type='bip32', encoding=encoding,
@@ -956,7 +956,7 @@ class HDWallet(object):
             new_wallet.main_key_id = mk.key_id
             session.commit()
 
-            w = cls(new_wallet_id, databasefile=databasefile, main_key_object=mk.key())
+            w = cls(new_wallet_id, db_uri=db_uri, main_key_object=mk.key())
             w.key_for_path([0, 0], account_id=account_id, cosigner_id=cosigner_id)
         elif scheme == 'single':
             if not key:
@@ -966,7 +966,7 @@ class HDWallet(object):
                                       witness_type=witness_type, multisig=multisig)
             new_wallet.main_key_id = mk.key_id
             session.commit()
-            w = cls(new_wallet_id, databasefile=databasefile, main_key_object=mk.key())
+            w = cls(new_wallet_id, db_uri=db_uri, main_key_object=mk.key())
 
         session.close()
         return w
@@ -974,7 +974,7 @@ class HDWallet(object):
     @classmethod
     def create(cls, name, keys=None, owner='', network=None, account_id=0, purpose=0, scheme='bip32',
                sort_keys=True, password='', witness_type=None, encoding=None, multisig=None, sigs_required=None,
-               cosigner_id=None, key_path=None, databasefile=None):
+               cosigner_id=None, key_path=None, db_uri=None):
         """
         Create HDWallet and insert in database. Generate masterkey or import key when specified.
 
@@ -986,9 +986,9 @@ class HDWallet(object):
 
         To create a native segwit wallet use the option witness_type = 'segwit' and for old style addresses and p2sh
         embedded segwit script us 'ps2h-segwit' as witness_type.
-        
+
         Please mention account_id if you are using multiple accounts.
-        
+
         :param name: Unique name of this Wallet
         :type name: str
         :param keys: Masterkey to or list of keys to use for this wallet. Will be automatically created if not specified. One or more keys are obligatory for multisig wallets. Can contain all key formats accepted by the HDKey object, a HDKey object or BIP39 passphrase
@@ -1024,10 +1024,10 @@ class HDWallet(object):
         * All keys must be hardened, except for change, address_index or cosigner_id
         * Max length of path is 8 levels
         :type key_path: list, str
-        :param databasefile: Location of database file. Leave empty to use default
-        :type databasefile: str
-        
-        :return HDWallet: 
+        :param db_uri: URI of the database
+        :type db_uri: str
+
+        :return HDWallet:
         """
 
         if multisig is None:
@@ -1119,7 +1119,7 @@ class HDWallet(object):
         hdpm = cls._create(name, key, owner=owner, network=network, account_id=account_id, purpose=purpose,
                            scheme=scheme, parent_id=None, sort_keys=sort_keys, witness_type=witness_type,
                            encoding=encoding, multisig=multisig, sigs_required=sigs_required, cosigner_id=cosigner_id,
-                           key_path=key_path, databasefile=databasefile)
+                           key_path=key_path, db_uri=db_uri)
 
         if multisig:
             if sort_keys:
@@ -1144,7 +1144,7 @@ class HDWallet(object):
                                 purpose=hdpm.purpose, scheme=scheme, parent_id=hdpm.wallet_id, sort_keys=sort_keys,
                                 witness_type=hdpm.witness_type, encoding=encoding, multisig=True,
                                 sigs_required=None, cosigner_id=wlt_cos_id, key_path=key_path,
-                                databasefile=databasefile)
+                                db_uri=db_uri)
                 hdpm.cosigner.append(w)
                 wlt_cos_id += 1
 
@@ -1153,7 +1153,7 @@ class HDWallet(object):
     @classmethod
     def create_multisig(cls, name, keys, sigs_required=None, owner='', network=None, account_id=0, purpose=None,
                         sort_keys=True, witness_type=DEFAULT_WITNESS_TYPE, encoding=None, key_path=None,
-                        cosigner_id=None, databasefile=None):
+                        cosigner_id=None, db_uri=None):
         """
         Create a multisig wallet with specified name and list of keys. The list of keys can contain 2 or more
         public or private keys. For every key a cosigner wallet will be created with a BIP44 key structure or a
@@ -1187,8 +1187,8 @@ class HDWallet(object):
         :type key_path: list, str
         :param cosigner_id: Set this if wallet contains only public keys or if you would like to create keys for other cosigners.
         :type cosigner_id: int
-        :param databasefile: Location of database file. Leave empty to use default
-        :type databasefile: str
+        :param db_uri: URI of the database
+        :type db_uri: str
 
         :return HDWallet:
 
@@ -1197,19 +1197,19 @@ class HDWallet(object):
         return cls.create(name, keys=keys, owner=owner, network=network, account_id=account_id, purpose=purpose,
                           sort_keys=sort_keys, witness_type=witness_type, encoding=encoding, multisig=True,
                           sigs_required=sigs_required, cosigner_id=cosigner_id, key_path=key_path,
-                          databasefile=databasefile)
+                          db_uri=db_uri)
 
     def __enter__(self):
         return self
 
-    def __init__(self, wallet, databasefile=DEFAULT_DATABASE, session=None, main_key_object=None):
+    def __init__(self, wallet, db_uri=None, session=None, main_key_object=None):
         """
         Open a wallet with given ID or name
-        
+
         :param wallet: Wallet name or ID
         :type wallet: int, str
-        :param databasefile: Location of database file. Leave empty to use default
-        :type databasefile: str
+        :param db_uri: URI of the database
+        :type db_uri: str
         :param session: Sqlalchemy session
         :type session: sqlalchemy.orm.session.Session
         :param main_key_object: Pass main key object to save time
@@ -1219,10 +1219,10 @@ class HDWallet(object):
         if session:
             self._session = session
         else:
-            dbinit = DbInit(databasefile=databasefile)
+            dbinit = DbInit(db_uri=db_uri)
             self._session = dbinit.session
             self._engine = dbinit.engine
-        self.databasefile = databasefile
+        self.db_uri = db_uri
         if isinstance(wallet, int) or wallet.isdigit():
             db_wlt = self._session.query(DbWallet).filter_by(id=wallet).scalar()
         else:
@@ -1243,7 +1243,7 @@ class HDWallet(object):
             self.multisig_n_required = db_wlt.multisig_n_required
             co_sign_wallets = self._session.query(DbWallet).\
                 filter(DbWallet.parent_id == self.wallet_id).order_by(DbWallet.name).all()
-            self.cosigner = [HDWallet(w.id, databasefile=databasefile) for w in co_sign_wallets]
+            self.cosigner = [HDWallet(w.id, db_uri=db_uri) for w in co_sign_wallets]
             self.sort_keys = db_wlt.sort_keys
             if db_wlt.main_key_id:
                 self.main_key = HDWalletKey(self.main_key_id, session=self._session, hdkey_object=main_key_object)
@@ -1288,8 +1288,8 @@ class HDWallet(object):
     #         pass
 
     def __repr__(self):
-        return "<HDWallet(name=%s, databasefile=\"%s\")>" % \
-               (self.name, self.databasefile)
+        return "<HDWallet(name=%s, db_uri=\"%s\")>" % \
+               (self.name, self.db_uri)
 
     def __str__(self):
         return self.name
@@ -1297,15 +1297,15 @@ class HDWallet(object):
     def _get_account_defaults(self, network=None, account_id=None, key_id=None):
         """
         Check parameter values for network and account ID, return defaults if no network or account ID is specified.
-        If a network is specified but no account ID this method returns the first account ID it finds. 
-        
+        If a network is specified but no account ID this method returns the first account ID it finds.
+
         :param network: Network code, leave empty for default
         :type network: str
         :param account_id: Account ID, leave emtpy for default
         :type account_id: int
         :param key_id: Key ID to just update 1 key
         :type key_id: int
-        
+
         :return: network code, account ID and DbKey instance of account ID key
         """
 
@@ -1348,8 +1348,8 @@ class HDWallet(object):
     def owner(self):
         """
         Get wallet Owner
-        
-        :return str: 
+
+        :return str:
         """
 
         return self._owner
@@ -1358,11 +1358,11 @@ class HDWallet(object):
     def owner(self, value):
         """
         Set wallet Owner in database
-        
+
         :param value: Owner
         :type value: str
-        
-        :return str: 
+
+        :return str:
         """
 
         self._owner = value
@@ -1374,8 +1374,8 @@ class HDWallet(object):
     def name(self):
         """
         Get wallet name
-        
-        :return str: 
+
+        :return str:
         """
 
         return self._name
@@ -1384,14 +1384,14 @@ class HDWallet(object):
     def name(self, value):
         """
         Set wallet name, update in database
-        
+
         :param value: Name for this wallet
         :type value: str
-        
-        :return str: 
+
+        :return str:
         """
 
-        if wallet_exists(value, databasefile=self.databasefile):
+        if wallet_exists(value, db_uri=self.db_uri):
             raise WalletError("Wallet with name '%s' already exists" % value)
         self._name = value
         self._session.query(DbWallet).filter(DbWallet.id == self.wallet_id).update({DbWallet.name: value})
@@ -1490,7 +1490,7 @@ class HDWallet(object):
     def import_key(self, key, account_id=0, name='', network=None, purpose=44, key_type=None):
         """
         Add new single key to wallet.
-        
+
         :param key: Key to import
         :type key: str, bytes, int, bytearray, HDKey, Address
         :param account_id: Account ID. Default is last used or created account ID.
@@ -1503,8 +1503,8 @@ class HDWallet(object):
         :type purpose: int
         :param key_type: Key type of imported key, can be single (unrelated to wallet, bip32, bip44 or master for new or extra master key import. Default is 'single'
         :type key_type: str
-        
-        :return HDWalletKey: 
+
+        :return HDWalletKey:
         """
 
         if self.scheme not in ['bip32', 'single']:
@@ -1603,7 +1603,7 @@ class HDWallet(object):
         """
         Create a new HD Key derived from this wallet's masterkey. An account will be created for this wallet
         with index 0 if there is no account defined yet.
-        
+
         :param name: Key name. Does not have to be unique but if you use it at reference you might chooce to enforce this. If not specified 'Key #' with an unique sequence number will be used
         :type name: str
         :param account_id: Account ID. Default is last used or created account ID.
@@ -1615,7 +1615,7 @@ class HDWallet(object):
         :param network: Network name. Leave empty for default network
         :type network: str
 
-        :return HDWalletKey: 
+        :return HDWalletKey:
         """
 
         if self.scheme == 'single':
@@ -1645,15 +1645,15 @@ class HDWallet(object):
     def new_key_change(self, name='', account_id=None, network=None):
         """
         Create new key to receive change for a transaction. Calls new_key method with change=1.
-        
+
         :param name: Key name. Default name is 'Change #' with an address index
         :type name: str
         :param account_id: Account ID. Default is last used or created account ID.
         :type account_id: int
         :param network: Network name. Leave empty for default network
         :type network: str
-                
-        :return HDWalletKey: 
+
+        :return HDWalletKey:
         """
 
         return self.new_key(name=name, account_id=account_id, network=network, change=1)
@@ -1756,9 +1756,9 @@ class HDWallet(object):
 
     def get_key(self, account_id=None, network=None, cosigner_id=None, number_of_keys=1, change=0):
         """
-        Get a unused key or create a new one if there are no unused keys. 
+        Get a unused key or create a new one if there are no unused keys.
         Returns a key from this wallet which has no transactions linked to it.
-        
+
         :param account_id: Account ID. Default is last used or created account ID.
         :type account_id: int
         :param network: Network name. Leave empty for default network
@@ -1770,7 +1770,7 @@ class HDWallet(object):
         :param change: Payment (0) or change key (1). Default is 0
         :type change: int
 
-        :return HDWalletKey: 
+        :return HDWalletKey:
         """
 
         network, account_id, _ = self._get_account_defaults(network, account_id)
@@ -1800,9 +1800,9 @@ class HDWallet(object):
 
     def get_key_change(self, account_id=None, network=None, number_of_keys=1):
         """
-        Get a unused change key or create a new one if there are no unused keys. 
+        Get a unused change key or create a new one if there are no unused keys.
         Wrapper for the get_key method
-        
+
         :param account_id: Account ID. Default is last used or created account ID.
         :type account_id: int
         :param network: Network name. Leave empty for default network
@@ -1810,7 +1810,7 @@ class HDWallet(object):
         :param number_of_keys: Number of keys to return. Default is 1
         :type number_of_keys: int
 
-        :return HDWalletKey:  
+        :return HDWalletKey:
         """
 
         return self.get_key(account_id=account_id, network=network, change=1, number_of_keys=number_of_keys)
@@ -1818,17 +1818,17 @@ class HDWallet(object):
     def new_account(self, name='', account_id=None, network=None):
         """
         Create a new account with a childkey for payments and 1 for change.
-        
+
         An account key can only be created if wallet contains a masterkey.
-        
+
         :param name: Account Name. If not specified 'Account #" with the account_id will be used
         :type name: str
         :param account_id: Account ID. Default is last accounts ID + 1
         :type account_id: int
         :param network: Network name. Leave empty for default network
         :type network: str
-        
-        :return HDWalletKey: 
+
+        :return HDWalletKey:
         """
 
         if self.scheme != 'bip32':
@@ -2009,10 +2009,10 @@ class HDWallet(object):
              has_balance=None, is_active=True, network=None, include_private=False, as_dict=False):
         """
         Search for keys in database. Include 0 or more of account_id, name, key_id, change and depth.
-        
+
         Returns a list of DbKey object or dictionary object if as_dict is True
-        
-        :param account_id: Search for account ID 
+
+        :param account_id: Search for account ID
         :type account_id: int
         :param name: Search for Name
         :type name: str
@@ -2036,7 +2036,7 @@ class HDWallet(object):
         :type include_private: bool
         :param as_dict: Return keys as dictionary objects. Default is False: DbKey objects
         :type as_dict: bool
-        
+
         :return list: List of Keys
         """
 
@@ -2093,9 +2093,9 @@ class HDWallet(object):
         :type used: bool
         :param as_dict: Return as dictionary or DbKey object. Default is False: DbKey objects
         :type as_dict: bool
-        
+
         :return list: DbKey or dictionaries
-        
+
         """
 
         if self.scheme != 'bip32':
@@ -2111,16 +2111,16 @@ class HDWallet(object):
     def keys_accounts(self, account_id=None, network=DEFAULT_NETWORK, as_dict=False):
         """
         Get Database records of account key(s) with for current wallet. Wrapper for the keys() method.
-        
+
         Returns nothing if no account keys are available for instance in multisig or single account wallets. In this case use accounts() method instead.
-        
+
         :param account_id: Search for Account ID
         :type account_id: int
         :param network: Network name filter
         :type network: str
         :param as_dict: Return as dictionary or DbKey object. Default is False: DbKey objects
         :type as_dict: bool
-        
+
         :return list: DbKey or dictionaries
         """
 
@@ -2140,7 +2140,7 @@ class HDWallet(object):
         :type depth: int
         :param as_dict: Return as dictionary or DbKey object. Default is False: DbKey objects
         :type as_dict: bool
-        
+
         :return list: DbKey or dictionaries
         """
 
@@ -2160,7 +2160,7 @@ class HDWallet(object):
         :type network: str
         :param as_dict: Return as dictionary or DbKey object. Default is False: DbKey objects
         :type as_dict: bool
-        
+
         :return list: DbKey or dictionaries
         """
 
@@ -2178,7 +2178,7 @@ class HDWallet(object):
         :type network: str
         :param as_dict: Return as dictionary or DbKey object. Default is False: DbKey objects
         :type as_dict: bool
-        
+
         :return list: DbKey or dictionaries
         """
 
@@ -2199,7 +2199,7 @@ class HDWallet(object):
         :type depth: int
         :param key_id: Key ID to get address of just 1 key
         :type key_id: int
-        
+
         :return list: List of address strings
         """
 
@@ -2219,7 +2219,7 @@ class HDWallet(object):
 
         :param term: Search term can be key ID, key address, key WIF or key name
         :type term: int, str
-        
+
         :return HDWalletKey: Single key as object
         """
 
@@ -2275,10 +2275,10 @@ class HDWallet(object):
     def accounts(self, network=DEFAULT_NETWORK):
         """
         Get list of accounts for this wallet
-        
+
         :param network: Network name filter. Default filter is DEFAULT_NETWORK
         :type network: str
-                
+
         :return list of integers: List of accounts IDs
         """
 
@@ -2326,7 +2326,7 @@ class HDWallet(object):
         """
         Wrapper for networks methods, returns a flat list with currently used
         networks for this wallet.
-        
+
         :return list of str:
         """
 
@@ -2390,15 +2390,15 @@ class HDWallet(object):
         if as_string:
             return Network(network).print_value(balance)
         else:
-            return balance
+            return float(balance)
 
     def _balance_update(self, account_id=None, network=None, key_id=None, min_confirms=0):
         """
         Update balance from UTXO's in database. To get most recent balance update UTXO's first.
-        
+
         Also updates balance of wallet and keys in this wallet for the specified account or all accounts if
         no account is specified.
-        
+
         :param account_id: Account ID filter
         :type account_id: int
         :param network: Network name. Leave empty for default network
@@ -2423,7 +2423,13 @@ class HDWallet(object):
             qr = qr.filter(DbKey.network_name == network)
         if key_id is not None:
             qr = qr.filter(DbKey.id == key_id)
-        utxos = qr.group_by(DbTransactionOutput.key_id).all()
+        utxos = qr.group_by(
+            DbTransactionOutput.key_id,
+            DbTransactionOutput.transaction_id,
+            DbTransactionOutput.output_n,
+            DbKey.network_name,
+            DbKey.account_id
+        ).all()
 
         key_values = [
             {
@@ -2473,7 +2479,7 @@ class HDWallet(object):
                      utxos=None, update_balance=True, max_utxos=MAX_TRANSACTIONS):
         """
         Update UTXO's (Unspent Outputs) in database of given account using the default Service object.
-        
+
         Delete old UTXO's which are spent and append new UTXO's to database.
 
         For usage on an offline PC, you can import utxos with the utxos parameter as a list of dictionaries:
@@ -2505,7 +2511,7 @@ class HDWallet(object):
         :param max_utxos: Maximum number of UTXO's to update
         :type max_utxos: int
 
-        :return int: Number of new UTXO's added 
+        :return int: Number of new UTXO's added
         """
 
         single_key = None
@@ -2618,7 +2624,7 @@ class HDWallet(object):
     def utxos(self, account_id=None, network=None, min_confirms=0, key_id=None):
         """
         Get UTXO's (Unspent Outputs) from database. Use utxos_update method first for updated values
-        
+
         :param account_id: Account ID
         :type account_id: int
         :param network: Network name. Leave empty for default network
@@ -2628,7 +2634,7 @@ class HDWallet(object):
         :param key_id: Key ID to just get 1 key
         :type key_id: int
 
-        :return list: List of transactions 
+        :return list: List of transactions
         """
 
         network, account_id, acckey = self._get_account_defaults(network, account_id, key_id)
@@ -3114,7 +3120,7 @@ class HDWallet(object):
                     address = '' if len(inp) <= 6 else inp[6]
                 # Get key_ids, value from Db if not specified
                 if not (key_id and value and unlocking_script_type):
-                    if not isinstance(output_n, int):
+                    if not isinstance(output_n, TYPE_INT):
                         output_n = struct.unpack('>I', output_n)[0]
                     inp_utxo = self._session.query(DbTransactionOutput).join(DbTransaction).join(DbKey). \
                         filter(DbTransaction.wallet_id == self.wallet_id,
@@ -3255,12 +3261,12 @@ class HDWallet(object):
     def send(self, output_arr, input_arr=None, input_key_id=None, account_id=None, network=None, fee=None,
              min_confirms=0, priv_keys=None, max_utxos=None, locktime=0, offline=False):
         """
-        Create new transaction with specified outputs and push it to the network. 
+        Create new transaction with specified outputs and push it to the network.
         Inputs can be specified but if not provided they will be selected from wallets utxo's.
         Output array is a list of 1 or more addresses and amounts.
-        
+
         :param output_arr: List of output tuples with address and amount. Must contain at least one item. Example: [('mxdLD8SAGS9fe2EeCXALDHcdTTbppMHp8N', 5000000)]. Address can be an address string, Address object, HDKey object or HDWalletKey object
-        :type output_arr: list 
+        :type output_arr: list
         :param input_arr: List of inputs tuples with reference to a UTXO, a wallet key and value. The format is [(tx_hash, output_n, key_id, value)]
         :type input_arr: list
         :param input_key_id: Limit UTXO's search for inputs to this key_id. Only valid if no input array is specified
@@ -3346,9 +3352,9 @@ class HDWallet(object):
     def sweep(self, to_address, account_id=None, input_key_id=None, network=None, max_utxos=999, min_confirms=0,
               fee_per_kb=None, fee=None, locktime=0, offline=False):
         """
-        Sweep all unspent transaction outputs (UTXO's) and send them to one output address. 
+        Sweep all unspent transaction outputs (UTXO's) and send them to one output address.
         Wrapper for the send method.
-        
+
         :param to_address: Single output address
         :type to_address: str
         :param account_id: Wallet's account ID
@@ -3459,7 +3465,7 @@ class HDWallet(object):
     def info(self, detail=3):
         """
         Prints wallet information to standard output
-        
+
         :param detail: Level of detail to show. Specify a number between 0 and 5, with 0 low detail and 5 highest detail
         :type detail: int
         """

--- a/examples/wallets.py
+++ b/examples/wallets.py
@@ -17,18 +17,18 @@ from bitcoinlib.mnemonic import Mnemonic
 #
 
 # First recreate database to avoid already exist errors
-test_databasefile = 'bitcoinlib.test.sqlite'
-test_database = BCL_DATABASE_DIR + test_databasefile
-if os.path.isfile(test_database):
-    os.remove(test_database)
+test_databasefile = BCL_DATABASE_DIR + 'bitcoinlib.test.sqlite'
+test_database = 'sqlite:///' + test_databasefile
+if os.path.isfile(test_databasefile):
+    os.remove(test_databasefile)
 
 print("\n=== Most simple way to create Bitcoin Wallet ===")
-w = HDWallet.create('MyWallet', databasefile=test_database)
+w = HDWallet.create('MyWallet', db_uri=test_database)
 w.new_key()
 w.info()
 
 print("\n=== Create new Testnet Wallet and generate a some new keys ===")
-with HDWallet.create(name='Personal', network='testnet', databasefile=test_database) as wallet:
+with HDWallet.create(name='Personal', network='testnet', db_uri=test_database) as wallet:
     wallet.info(detail=3)
     wallet.new_account()
     new_key1 = wallet.new_key()
@@ -50,7 +50,7 @@ testnet_wallet = HDWallet.create(
          '7irEvBoe4aAn52',
     network='testnet',
     account_id=99,
-    databasefile=test_database)
+    db_uri=test_database)
 nk = testnet_wallet.new_key(account_id=99, name="Address #1")
 nk2 = testnet_wallet.new_key(account_id=99, name="Address #2")
 nkc = testnet_wallet.new_key_change(account_id=99, name="Change #1")
@@ -72,7 +72,7 @@ print("\n=== Import Account Bitcoin Testnet key with depth 3 ===")
 accountkey = 'tprv8h4wEmfC2aSckSCYa68t8MhL7F8p9xAy322B5d6ipzY5ZWGGwksJMoajMCqd73cP4EVRygPQubgJPu9duBzPn3QV' \
              '8Y7KbKUnaMzxnnnsSvh'
 wallet_import2 = HDWallet.create(
-    databasefile=test_database,
+    db_uri=test_database,
     name='Account Import',
     keys=accountkey,
     network='testnet',
@@ -84,7 +84,7 @@ print("\n=== Create simple wallet and import some unrelated private keys ===")
 simple_wallet = HDWallet.create(
     name='Simple Wallet',
     keys='L5fbTtqEKPK6zeuCBivnQ8FALMEq6ZApD7wkHZoMUsBWcktBev73',
-    databasefile=test_database)
+    db_uri=test_database)
 simple_wallet.import_key('KxVjTaa4fd6gaga3YDDRDG56tn1UXdMF9fAMxehUH83PTjqk4xCs')
 simple_wallet.import_key('L3RyKcjp8kzdJ6rhGhTC5bXWEYnC2eL3b1vrZoduXMht6m9MQeHy')
 simple_wallet.utxos_update()
@@ -95,7 +95,7 @@ print("\n=== Create wallet with public key to generate addresses without private
 pubkey = 'tpubDDkyPBhSAx8DFYxx5aLjvKH6B6Eq2eDK1YN76x1WeijE8eVUswpibGbv8zJjD6yLDHzVcqWzSp2fWVFhEW9XnBssFqM' \
          'wt9SrsVeBeqfBbR3'
 pubwal = HDWallet.create(
-    databasefile=test_database,
+    db_uri=test_database,
     name='Import Public Key Wallet',
     keys=pubkey,
     network='testnet')
@@ -105,7 +105,7 @@ del pubwal
 
 print("\n=== Create Litecoin wallet ===")
 litecoin_wallet = HDWallet.create(
-    databasefile=test_database,
+    db_uri=test_database,
     name='Litecoin Wallet',
     network='litecoin')
 litecoin_wallet.new_key()
@@ -114,7 +114,7 @@ del litecoin_wallet
 
 print("\n=== Create Dash wallet ===")
 dash_wallet = HDWallet.create(
-    databasefile=test_database,
+    db_uri=test_database,
     name='Dash Wallet',
     network='dash')
 dash_wallet.new_key()
@@ -129,7 +129,7 @@ print("Generated Passphrase: %s" % words)
 seed = Mnemonic().to_seed(words)
 hdkey = HDKey.from_seed(seed, network='litecoin_testnet')
 wallet = HDWallet.create(name='Mnemonic Wallet', network='litecoin_testnet',
-                         keys=hdkey.wif(), databasefile=test_database)
+                         keys=hdkey.wif(), db_uri=test_database)
 wallet.new_key("Input", 0)
 wallet.utxos_update()
 wallet.info(detail=3)
@@ -137,7 +137,7 @@ wallet.info(detail=3)
 print("\n=== Test import Litecoin key in Bitcoin wallet (should give error) ===")
 w = HDWallet.create(
     name='Wallet Error',
-    databasefile=test_database)
+    db_uri=test_database)
 try:
     w.import_key(key='T43gB4F6k1Ly3YWbMuddq13xLb56hevUDP3RthKArr7FPHjQiXpp', network='litecoin')
 except WalletError as e:
@@ -148,7 +148,7 @@ key_path = "m/44h/1'/0p/2000/1"
 print("Raw: %s, Normalized: %s" % (key_path, normalize_path(key_path)))
 
 print("\n=== Send test bitcoins to an address ===")
-wallet_import = HDWallet('TestNetWallet', databasefile=test_database)
+wallet_import = HDWallet('TestNetWallet', db_uri=test_database)
 for _ in range(10):
     wallet_import.new_key()
 wallet_import.utxos_update(99)
@@ -170,13 +170,13 @@ except Exception as e:
 # Segwit wallets
 #
 print("\n=== Create a Segwit Bitcoin and Litecoin Wallet ===")
-w = HDWallet.create('SW-Wallet', witness_type='segwit', databasefile=test_database)
+w = HDWallet.create('SW-Wallet', witness_type='segwit', db_uri=test_database)
 w.new_key()
 w.new_key(network='litecoin')
 w.info()
 
 print("\n=== Create a P2SH Segwit Bitcoin and Litecoin Wallet ===")
-w = HDWallet.create('P2SH-segwit-Wallet', witness_type='p2sh-segwit', databasefile=test_database)
+w = HDWallet.create('P2SH-segwit-Wallet', witness_type='p2sh-segwit', db_uri=test_database)
 w.new_key()
 w.new_key(network='litecoin')
 w.info()
@@ -185,6 +185,6 @@ w.info()
 # Manage Wallets
 #
 print("\n=== List wallets & delete a wallet ===")
-print(','.join([w['name'] for w in wallets_list(databasefile=test_database)]))
-res = wallet_delete('Personal', databasefile=test_database, force=True)
-print(','.join([w['name'] for w in wallets_list(databasefile=test_database)]))
+print(','.join([w['name'] for w in wallets_list(db_uri=test_database)]))
+res = wallet_delete('Personal', db_uri=test_database, force=True)
+print(','.join([w['name'] for w in wallets_list(db_uri=test_database)]))

--- a/examples/wallets_mnemonic.py
+++ b/examples/wallets_mnemonic.py
@@ -8,7 +8,6 @@
 #
 
 import os
-from pprint import pprint
 from bitcoinlib.wallets import HDWallet, BCL_DATABASE_DIR
 from bitcoinlib.mnemonic import Mnemonic
 try:
@@ -21,17 +20,17 @@ except NameError:
 #
 
 # First recreate database to avoid already exist errors
-test_databasefile = 'bitcoinlib.test.sqlite'
-test_database = BCL_DATABASE_DIR + test_databasefile
-if os.path.isfile(test_database):
-    os.remove(test_database)
+test_databasefile = BCL_DATABASE_DIR + 'bitcoinlib.test.sqlite'
+test_database = 'sqlite:///' + test_databasefile
+if os.path.isfile(test_databasefile):
+    os.remove(test_databasefile)
 
 print("\n=== Create a simple Mnemonic wallet ===")
 passphrase = Mnemonic().generate()
 print("Your private key passphrase is:", passphrase)
 password = input("Enter password to protect passphrase: ")
 wlt = HDWallet.create('mnwlttest1', keys=passphrase, password=password, network='bitcoinlib_test',
-                      databasefile=test_database)
+                      db_uri=test_database)
 wlt.get_key()
 wlt.utxos_update()  # Create some test UTXOs
 wlt.info()

--- a/examples/wallets_multisig.py
+++ b/examples/wallets_multisig.py
@@ -11,10 +11,10 @@ import os
 from pprint import pprint
 from bitcoinlib.wallets import *
 
-test_databasefile = 'bitcoinlib.test.sqlite'
-test_database = BCL_DATABASE_DIR + test_databasefile
-if os.path.isfile(test_database):
-    os.remove(test_database)
+test_databasefile = BCL_DATABASE_DIR + 'bitcoinlib.test.sqlite'
+test_database = 'sqlite:///' + test_databasefile
+if os.path.isfile(test_databasefile):
+    os.remove(test_databasefile)
 
 #
 # Create a multi-signature wallet using Bitcoinlib testnet and then create a transaction
@@ -27,13 +27,13 @@ pk2 = HDKey(network=NETWORK)
 pk3 = HDKey(network=NETWORK)
 klist = [pk1, pk2.public_master_multisig(), pk3.public_master_multisig()]
 wl1 = HDWallet.create('multisig_2of3_cosigner1', sigs_required=2, keys=klist,
-                      network=NETWORK, databasefile=test_database)
+                      network=NETWORK, db_uri=test_database)
 klist = [pk1.public_master_multisig(), pk2, pk3.public_master_multisig()]
 wl2 = HDWallet.create('multisig_2of3_cosigner2',  sigs_required=2, keys=klist,
-                      network=NETWORK, databasefile=test_database)
+                      network=NETWORK, db_uri=test_database)
 klist = [pk1.public_master_multisig(), pk2.public_master_multisig(), pk3]
 wl3 = HDWallet.create('multisig_2of3_cosigner3', sigs_required=2, keys=klist,
-                      network=NETWORK, databasefile=test_database)
+                      network=NETWORK, db_uri=test_database)
 
 # Generate a new key in each wallet, all these keys should be the same
 nk1 = wl1.new_key(cosigner_id=1)
@@ -74,10 +74,10 @@ pk2 = HDKey('tprv8ZgxMBicQKsPeUbMS6kswJc11zgVEXUnUZuGo3bF6bBrAg1ieFfUdPc9UHqbD5H
             'MeQHdWDp', network=NETWORK)
 wl1 = HDWallet.create('multisig_2of2_cosigner1', sigs_required=2,
                       keys=[pk1, pk2.public_master_multisig()],
-                      network=NETWORK, databasefile=test_database)
+                      network=NETWORK, db_uri=test_database)
 wl2 = HDWallet.create('multisig_2of2_cosigner2', sigs_required=2,
                       keys=[pk1.public_master_multisig(), pk2],
-                      network=NETWORK, databasefile=test_database)
+                      network=NETWORK, db_uri=test_database)
 nk1 = wl1.new_key()
 nk2 = wl2.new_key(cosigner_id=0)
 
@@ -107,9 +107,9 @@ pk1 = HDKey('YXscyqNJ5YK411nwB33KeVkhSVjwwUkSG9xG3hkaoQFEbTwNJSrNTfni3aSSYiKtPeU
 pk2 = HDKey('YXscyqNJ5YK411nwB3kXiApMaJySYss8sMM9FYgXMtmQKmDTF9yiu7yBNKnVjE8WdVVvuhxLqS6kHvW2MPHKmYzbzEHQsDXXAZuu1rCs'
             'Hcp7rrJx', network=NETWORK, key_type='single')
 wl1 = HDWallet.create('multisig_single_keys1', [pk1, pk2.public()],
-                      sigs_required=2, network=NETWORK, databasefile=test_database)
+                      sigs_required=2, network=NETWORK, db_uri=test_database)
 wl2 = HDWallet.create('multisig_single_keys2', [pk1.public_master_multisig(), pk2],
-                      sigs_required=2, network=NETWORK, databasefile=test_database)
+                      sigs_required=2, network=NETWORK, db_uri=test_database)
 
 # Create multisig keys and update UTXO's
 wl1.new_key(cosigner_id=0)
@@ -136,6 +136,6 @@ pk2 = HDKey(network=NETWORK, witness_type='segwit')                     # Wallet
 pk3 = HDKey(network=NETWORK, witness_type='segwit', key_type='single')  # Backup key on paper
 
 w = HDWallet.create('Segwit-multisig-2-of-3-wallet', [pk1, pk2.public_master_multisig(), pk3.public()],
-                    sigs_required=2, network=NETWORK, databasefile=test_database)
+                    sigs_required=2, network=NETWORK, db_uri=test_database)
 
 w.info()

--- a/examples/wallets_transactions.py
+++ b/examples/wallets_transactions.py
@@ -17,13 +17,13 @@ from bitcoinlib.wallets import HDWallet, BCL_DATABASE_DIR
 #
 
 # First recreate database to avoid already exist errors
-test_databasefile = 'bitcoinlib.test.sqlite'
-test_database = BCL_DATABASE_DIR + test_databasefile
-if os.path.isfile(test_database):
-    os.remove(test_database)
+test_databasefile = BCL_DATABASE_DIR + 'bitcoinlib.test.sqlite'
+test_database = 'sqlite:///' + test_databasefile
+if os.path.isfile(test_databasefile):
+    os.remove(test_databasefile)
 
 print("\n=== Create a wallet and a simple transaction ===")
-wlt = HDWallet.create('wlttest1', network='bitcoinlib_test', databasefile=test_database)
+wlt = HDWallet.create('wlttest1', network='bitcoinlib_test', db_uri=test_database)
 wlt.get_key()
 wlt.utxos_update()  # Create some test UTXOs
 wlt.info()
@@ -37,7 +37,7 @@ wlt.info()
 
 
 print("\n=== Create a wallet, generate 6 UTXOs and create a sweep transaction ===")
-wlt = HDWallet.create('wlttest2', network='bitcoinlib_test', databasefile=test_database)
+wlt = HDWallet.create('wlttest2', network='bitcoinlib_test', db_uri=test_database)
 wlt.get_key(number_of_keys=3)
 wlt.utxos_update()  # Create some test UTXOs
 wlt.info()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -9,19 +9,47 @@ import os
 import sys
 import unittest
 from subprocess import Popen, PIPE
+
+import psycopg2
+from parameterized import parameterized_class
+from psycopg2 import sql
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
 from bitcoinlib.encoding import normalize_string
 from bitcoinlib.db import BCL_DATABASE_DIR
 
 
-DATABASEFILE_UNITTESTS = 'bitcoinlib.unittest.sqlite'
+SQLITE_DATABASE_FILE = os.path.join(BCL_DATABASE_DIR, 'bitcoinlib.unittest.sqlite')
+DATABASE_NAME = 'bitcoinlib_unittest'
 
 
+def init_sqlite(_):
+    if os.path.isfile(SQLITE_DATABASE_FILE):
+        os.remove(SQLITE_DATABASE_FILE)
+
+
+def init_postgresql(_):
+    con = psycopg2.connect(user='postgres', host='localhost', password='postgres')
+    con.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    cur = con.cursor()
+    cur.execute(sql.SQL("DROP DATABASE IF EXISTS {}").format(
+        sql.Identifier(DATABASE_NAME))
+    )
+    cur.execute(sql.SQL("CREATE DATABASE {}").format(
+        sql.Identifier(DATABASE_NAME))
+    )
+    cur.close()
+    con.close()
+
+
+@parameterized_class(('DATABASE_URI', 'init_fn'), (
+        ('postgresql://postgres:postgres@localhost:5432/' + DATABASE_NAME, init_postgresql),
+        ('sqlite:///' + SQLITE_DATABASE_FILE, init_sqlite),
+))
 class TestToolsCommandLineWallet(unittest.TestCase):
 
     def setUp(self):
-        full_db_filename = os.path.join(BCL_DATABASE_DIR, DATABASEFILE_UNITTESTS)
-        if os.path.isfile(full_db_filename):
-            os.remove(full_db_filename)
+        self.init_fn()
         self.python_executable = sys.executable
         self.clw_executable = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                                             '../bitcoinlib/tools/cli_wallet.py'))
@@ -29,9 +57,9 @@ class TestToolsCommandLineWallet(unittest.TestCase):
     def test_tools_clw_create_wallet(self):
         cmd_wlt_create = '%s %s test --passphrase "emotion camp sponsor curious bacon squeeze bean world ' \
                          'actual chicken obscure spray" -r -d %s' % \
-                         (self.python_executable, self.clw_executable, DATABASEFILE_UNITTESTS)
+                         (self.python_executable, self.clw_executable, self.DATABASE_URI)
         cmd_wlt_delete = "%s %s test --wallet-remove -d %s" % \
-                         (self.python_executable, self.clw_executable, DATABASEFILE_UNITTESTS)
+                         (self.python_executable, self.clw_executable, self.DATABASE_URI)
         output_wlt_create = "14guS7uQpEbgf1e8TDo1zTEURJW3NGPc9E"
         output_wlt_delete = "Wallet test has been removed"
 
@@ -50,9 +78,9 @@ class TestToolsCommandLineWallet(unittest.TestCase):
             'MeQHdWDp'
         ]
         cmd_wlt_create = "%s %s testms -m 2 2 %s -r -n testnet -d %s" % \
-                         (self.python_executable, self.clw_executable, ' '.join(key_list), DATABASEFILE_UNITTESTS)
+                         (self.python_executable, self.clw_executable, ' '.join(key_list), self.DATABASE_URI)
         cmd_wlt_delete = "%s %s testms --wallet-remove -d %s" % \
-                         (self.python_executable, self.clw_executable, DATABASEFILE_UNITTESTS)
+                         (self.python_executable, self.clw_executable, self.DATABASE_URI)
         output_wlt_create = "2NBrLTapyFqU4Wo29xG4QeEt8kn38KVWRR"
         output_wlt_delete = "Wallet testms has been removed"
 
@@ -69,9 +97,9 @@ class TestToolsCommandLineWallet(unittest.TestCase):
             '5zNYeiX8'
         ]
         cmd_wlt_create = "%s %s testms1 -m 2 2 %s -r -n testnet -d %s" % \
-                         (self.python_executable, self.clw_executable, ' '.join(key_list), DATABASEFILE_UNITTESTS)
+                         (self.python_executable, self.clw_executable, ' '.join(key_list), self.DATABASE_URI)
         cmd_wlt_delete = "%s %s testms1 --wallet-remove -d %s" % \
-                         (self.python_executable, self.clw_executable, DATABASEFILE_UNITTESTS)
+                         (self.python_executable, self.clw_executable, self.DATABASE_URI)
         output_wlt_create = "if you understood and wrote down your key: Receive address(es):"
         output_wlt_delete = "Wallet testms1 has been removed"
 
@@ -84,7 +112,7 @@ class TestToolsCommandLineWallet(unittest.TestCase):
 
     def test_tools_clw_create_multisig_wallet_error(self):
         cmd_wlt_create = "%s %s testms2 -m 2 a -d %s" % \
-                         (self.python_executable, self.clw_executable, DATABASEFILE_UNITTESTS)
+                         (self.python_executable, self.clw_executable, self.DATABASE_URI)
         output_wlt_create = "Number of signatures required (second argument) must be a numeric value"
         process = Popen(cmd_wlt_create, stdin=PIPE, stdout=PIPE, shell=True)
         poutput = process.communicate(input=b'y')
@@ -93,13 +121,13 @@ class TestToolsCommandLineWallet(unittest.TestCase):
     def test_tools_clw_transaction_with_script(self):
         cmd_wlt_create = '%s %s test2 --passphrase "emotion camp sponsor curious bacon squeeze bean world ' \
                          'actual chicken obscure spray" -r -n bitcoinlib_test -d %s' % \
-                         (self.python_executable, self.clw_executable, DATABASEFILE_UNITTESTS)
+                         (self.python_executable, self.clw_executable, self.DATABASE_URI)
         cmd_wlt_update = "%s %s test2 -d %s" % \
-                         (self.python_executable, self.clw_executable, DATABASEFILE_UNITTESTS)
+                         (self.python_executable, self.clw_executable, self.DATABASE_URI)
         cmd_wlt_transaction = "%s %s test2 -d %s -t 21HVXMEdxdgjNzgfERhPwX4okXZ8WijHkvu 50000000 -f 100000 -p" % \
-                              (self.python_executable, self.clw_executable, DATABASEFILE_UNITTESTS)
+                              (self.python_executable, self.clw_executable, self.DATABASE_URI)
         cmd_wlt_delete = "%s %s test2 --wallet-remove -d %s" % \
-                         (self.python_executable, self.clw_executable, DATABASEFILE_UNITTESTS)
+                         (self.python_executable, self.clw_executable, self.DATABASE_URI)
         output_wlt_create = "21GPfxeCbBunsVev4uS6exPhqE8brPs1ZDF"
         output_wlt_transaction = 'Transaction pushed to network'
         output_wlt_delete = "Wallet test2 has been removed"
@@ -122,9 +150,9 @@ class TestToolsCommandLineWallet(unittest.TestCase):
     def test_tools_clw_create_litecoin_segwit_wallet(self):
         cmd_wlt_create = '%s %s ltcsw --passphrase "lounge chief tip frog camera build trouble write end ' \
                          'sword order share" -r -d %s -y segwit -n litecoin' % \
-                         (self.python_executable, self.clw_executable, DATABASEFILE_UNITTESTS)
+                         (self.python_executable, self.clw_executable, self.DATABASE_URI)
         cmd_wlt_delete = "%s %s ltcsw --wallet-remove -d %s" % \
-                         (self.python_executable, self.clw_executable, DATABASEFILE_UNITTESTS)
+                         (self.python_executable, self.clw_executable, self.DATABASE_URI)
         output_wlt_create = "ltc1qgc7c2z56rr4lftg0fr8tgh2vknqc3yuydedu6m"
         output_wlt_delete = "Wallet ltcsw has been removed"
 
@@ -145,10 +173,10 @@ class TestToolsCommandLineWallet(unittest.TestCase):
             '7FW6wpKW'
         ]
         cmd_wlt_create = "%s %s testms-p2sh-segwit -m 3 2 %s -r -y p2sh-segwit -d %s" % \
-                         (self.python_executable, self.clw_executable, ' '.join(key_list), DATABASEFILE_UNITTESTS)
+                         (self.python_executable, self.clw_executable, ' '.join(key_list), self.DATABASE_URI)
         print(cmd_wlt_create)
         cmd_wlt_delete = "%s %s testms-p2sh-segwit --wallet-remove -d %s" % \
-                         (self.python_executable, self.clw_executable, DATABASEFILE_UNITTESTS)
+                         (self.python_executable, self.clw_executable, self.DATABASE_URI)
         output_wlt_create = "3MtNi5U2cjs3EcPizzjarSz87pU9DTANge"
         output_wlt_delete = "Wallet testms-p2sh-segwit has been removed"
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,14 +10,14 @@ import sys
 import unittest
 from subprocess import Popen, PIPE
 
+import mysql.connector
 import psycopg2
 from parameterized import parameterized_class
 from psycopg2 import sql
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
-from bitcoinlib.encoding import normalize_string
 from bitcoinlib.db import BCL_DATABASE_DIR
-
+from bitcoinlib.encoding import normalize_string
 
 SQLITE_DATABASE_FILE = os.path.join(BCL_DATABASE_DIR, 'bitcoinlib.unittest.sqlite')
 DATABASE_NAME = 'bitcoinlib_unittest'
@@ -42,7 +42,18 @@ def init_postgresql(_):
     con.close()
 
 
+def init_mysql(_):
+    con = mysql.connector.connect(user='root', host='localhost')
+    cur = con.cursor()
+    cur.execute("DROP DATABASE IF EXISTS {}".format(DATABASE_NAME))
+    cur.execute("CREATE DATABASE {}".format(DATABASE_NAME))
+    con.commit()
+    cur.close()
+    con.close()
+
+
 @parameterized_class(('DATABASE_URI', 'init_fn'), (
+        ('mysql://root@localhost:3306/' + DATABASE_NAME, init_mysql),
         ('postgresql://postgres:postgres@localhost:5432/' + DATABASE_NAME, init_postgresql),
         ('sqlite:///' + SQLITE_DATABASE_FILE, init_sqlite),
 ))

--- a/tests/test_wallets.py
+++ b/tests/test_wallets.py
@@ -20,7 +20,11 @@
 
 import unittest
 from random import shuffle
-import datetime
+
+import psycopg2
+from parameterized import parameterized_class
+from psycopg2 import sql
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from sqlalchemy.orm import close_all_sessions
 from bitcoinlib.wallets import *
 from bitcoinlib.mnemonic import Mnemonic
@@ -30,24 +34,73 @@ from tests.test_custom import CustomAssertions
 
 DATABASEFILE_UNITTESTS = os.path.join(BCL_DATABASE_DIR, 'bitcoinlib.unittest.sqlite')
 DATABASEFILE_UNITTESTS_2 = os.path.join(BCL_DATABASE_DIR, 'bitcoinlib.unittest2.sqlite')
+DATABASE_NAME = 'bitcoinlib_test'
+DATABASE_NAME_2 = 'bitcoinlib2_test'
 
 
-def db_remove(db=DATABASEFILE_UNITTESTS):
-    close_all_sessions()
-    if os.path.isfile(db):
-        os.remove(db)
+params = (('SCHEMA','DATABASE_URI', 'DATABASE_URI_2'), (
+        ('postgresql', 'postgresql://postgres:postgres@localhost:5432/' + DATABASE_NAME, 'postgresql://postgres:postgres@localhost:5432/' + DATABASE_NAME_2),
+        ('sqlite', 'sqlite:///' + DATABASEFILE_UNITTESTS, 'sqlite:///' + DATABASEFILE_UNITTESTS_2),
+))
 
 
-class TestWalletCreate(unittest.TestCase):
+class TestWalletMixin:
+
+    @classmethod
+    def create_db_if_needed(cls, db):
+        con = psycopg2.connect(user='postgres', host='localhost', password='postgres')
+        con.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        cur = con.cursor()
+        try:
+            cur.execute(sql.SQL("CREATE DATABASE {}").format(
+                sql.Identifier(db))
+            )
+        except Exception:
+            pass
+        finally:
+            cur.close()
+            con.close()
+
+    @classmethod
+    def db_remove(cls):
+        close_all_sessions()
+        if cls.SCHEMA == 'sqlite':
+            for db in [DATABASEFILE_UNITTESTS, DATABASEFILE_UNITTESTS_2]:
+                if os.path.isfile(db):
+                    os.remove(db)
+        elif cls.SCHEMA =='postgresql':
+            for db in [DATABASE_NAME, DATABASE_NAME_2]:
+                cls.create_db_if_needed(db)
+                con = psycopg2.connect(user='postgres', host='localhost', password='postgres', database=db)
+                con.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+                cur = con.cursor()
+                try:
+                    # drop all tables
+                    cur.execute(sql.SQL("""
+                        DO $$ DECLARE
+                            r RECORD;
+                        BEGIN
+                            FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = current_schema()) LOOP
+                                EXECUTE 'DROP TABLE IF EXISTS ' || quote_ident(r.tablename) || ' CASCADE';
+                            END LOOP;
+                        END $$;"""
+                    ))
+                finally:
+                    cur.close()
+                    con.close()
+
+
+@parameterized_class(*params)
+class TestWalletCreate(TestWalletMixin, unittest.TestCase):
 
     wallet = None
 
     @classmethod
     def setUpClass(cls):
-        db_remove()
+        cls.db_remove()
         cls.wallet = HDWallet.create(
             name='test_wallet_create',
-            databasefile=DATABASEFILE_UNITTESTS)
+            db_uri=cls.DATABASE_URI)
 
     def test_wallet_create(self):
         self.assertTrue(isinstance(self.wallet, HDWallet))
@@ -56,12 +109,12 @@ class TestWalletCreate(unittest.TestCase):
         self.assertIsNone(self.wallet.info())
         self.assertTrue(self.wallet.as_dict())
         self.assertTrue(self.wallet.as_json())
-        self.assertIn("<HDWallet(name=test_wallet_create, databasefile=", repr(self.wallet))
+        self.assertIn("<HDWallet(name=test_wallet_create, db_uri=", repr(self.wallet))
         print(self.wallet)
 
     def test_wallet_exists(self):
-        self.assertTrue(wallet_exists(self.wallet.wallet_id, databasefile=DATABASEFILE_UNITTESTS))
-        self.assertTrue(wallet_exists('test_wallet_create', databasefile=DATABASEFILE_UNITTESTS))
+        self.assertTrue(wallet_exists(self.wallet.wallet_id, db_uri=self.DATABASE_URI))
+        self.assertTrue(wallet_exists('test_wallet_create', db_uri=self.DATABASE_URI))
 
     def test_wallet_key_info(self):
         self.assertIsNone(self.wallet.main_key.key().info())
@@ -80,24 +133,24 @@ class TestWalletCreate(unittest.TestCase):
         self.assertEqual(new_key.path, "m/44'/0'/200'/0/0")
 
     def test_wallets_list(self):
-        wallets = wallets_list(databasefile=DATABASEFILE_UNITTESTS)
+        wallets = wallets_list(db_uri=self.DATABASE_URI)
         self.assertEqual(wallets[0]['name'], 'test_wallet_create')
 
     def test_delete_wallet(self):
         HDWallet.create(
             name='wallet_to_remove',
-            databasefile=DATABASEFILE_UNITTESTS)
-        self.assertEqual(wallet_delete('wallet_to_remove', databasefile=DATABASEFILE_UNITTESTS), 1)
+            db_uri=self.DATABASE_URI)
+        self.assertEqual(wallet_delete('wallet_to_remove', db_uri=self.DATABASE_URI), 1)
 
     def test_wallet_empty(self):
-        w = HDWallet.create('empty_wallet_test', databasefile=DATABASEFILE_UNITTESTS)
+        w = HDWallet.create('empty_wallet_test', db_uri=self.DATABASE_URI)
         self.assertNotEqual(len(w.keys()), 1)
         master_key = w.public_master().key()
-        w2 = HDWallet.create('empty_wallet_test2', keys=master_key, databasefile=DATABASEFILE_UNITTESTS)
-        w3 = HDWallet.create('empty_wallet_test3', keys=master_key, databasefile=DATABASEFILE_UNITTESTS)
-        wallet_empty('empty_wallet_test', databasefile=DATABASEFILE_UNITTESTS)
-        wallet_empty('empty_wallet_test2', databasefile=DATABASEFILE_UNITTESTS)
-        wallet_empty(w3.wallet_id, databasefile=DATABASEFILE_UNITTESTS)
+        w2 = HDWallet.create('empty_wallet_test2', keys=master_key, db_uri=self.DATABASE_URI)
+        w3 = HDWallet.create('empty_wallet_test3', keys=master_key, db_uri=self.DATABASE_URI)
+        wallet_empty('empty_wallet_test', db_uri=self.DATABASE_URI)
+        wallet_empty('empty_wallet_test2', db_uri=self.DATABASE_URI)
+        wallet_empty(w3.wallet_id, db_uri=self.DATABASE_URI)
         self.assertEqual(len(w.keys()), 1)
         self.assertEqual(len(w2.keys()), 1)
         self.assertEqual(len(w3.keys()), 1)
@@ -105,18 +158,18 @@ class TestWalletCreate(unittest.TestCase):
         self.assertRaisesRegexp(WalletError, "Wallet 'unknown_wallet_2' not found", wallet_empty, 'unknown_wallet_2')
 
     def test_wallet_delete_not_empty(self):
-        w = HDWallet.create('unempty_wallet_test', network='bitcoinlib_test', databasefile=DATABASEFILE_UNITTESTS)
+        w = HDWallet.create('unempty_wallet_test', network='bitcoinlib_test', db_uri=self.DATABASE_URI)
         w.utxos_update()
         self.assertRaisesRegexp(WalletError, "still has unspent outputs. Use 'force=True' to delete this wallet",
-                                wallet_delete, 'unempty_wallet_test', databasefile=DATABASEFILE_UNITTESTS)
-        self.assertTrue(wallet_delete('unempty_wallet_test', databasefile=DATABASEFILE_UNITTESTS, force=True))
+                                wallet_delete, 'unempty_wallet_test', db_uri=self.DATABASE_URI)
+        self.assertTrue(wallet_delete('unempty_wallet_test', db_uri=self.DATABASE_URI, force=True))
 
     def test_delete_wallet_exception(self):
-        self.assertRaisesRegexp(WalletError, '', wallet_delete, 'unknown_wallet', databasefile=DATABASEFILE_UNITTESTS)
+        self.assertRaisesRegexp(WalletError, '', wallet_delete, 'unknown_wallet', db_uri=self.DATABASE_URI)
 
     def test_wallet_unknown_error(self):
         self.assertRaisesRegexp(WalletError, "Wallet 'test_wallet_create_errors10' not found",
-                                HDWallet, 'test_wallet_create_errors10', databasefile=DATABASEFILE_UNITTESTS)
+                                HDWallet, 'test_wallet_create_errors10', db_uri=self.DATABASE_URI)
 
     def test_wallet_duplicate_key_for_path(self):
         nkfp = self.wallet.key_for_path("m/44'/0'/100'/1200/1200")
@@ -131,90 +184,91 @@ class TestWalletCreate(unittest.TestCase):
     def test_wallet_create_with_passphrase(self):
         passphrase = "always reward element perfect chunk father margin slab pond suffer episode deposit"
         wlt = HDWallet.create("wallet-passphrase", keys=passphrase, network='testnet',
-                              databasefile=DATABASEFILE_UNITTESTS)
+                              db_uri=self.DATABASE_URI)
         key0 = wlt.get_key()
         self.assertEqual(key0.address, "mqDeXXaFnWKNWhLmAae7zHhZDW4PMsLHPp")
 
     def test_wallet_create_with_passphrase_litecoin(self):
         passphrase = "always reward element perfect chunk father margin slab pond suffer episode deposit"
         wlt = HDWallet.create("wallet-passphrase-litecoin", keys=passphrase, network='litecoin',
-                              databasefile=DATABASEFILE_UNITTESTS)
+                              db_uri=self.DATABASE_URI)
         keys = wlt.get_key(number_of_keys=5)
         self.assertEqual(keys[4].address, "Li5nEi62nAKWjv6fpixEpoLzN1pYFK621g")
 
     def test_wallet_create_change_name(self):
-        wlt = HDWallet.create('test_wallet_create_change_name', databasefile=DATABASEFILE_UNITTESTS)
+        wlt = HDWallet.create('test_wallet_create_change_name', db_uri=self.DATABASE_URI)
         wlt.name = 'wallet_renamed'
-        wlt2 = HDWallet('wallet_renamed', databasefile=DATABASEFILE_UNITTESTS)
+        wlt2 = HDWallet('wallet_renamed', db_uri=self.DATABASE_URI)
         self.assertEqual(wlt2.name, 'wallet_renamed')
 
     def test_wallet_create_errors(self):
-        HDWallet.create('test_wallet_create_errors', databasefile=DATABASEFILE_UNITTESTS)
+        HDWallet.create('test_wallet_create_errors', db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError, "Wallet with name 'test_wallet_create_errors' already exists",
-                                HDWallet.create, 'test_wallet_create_errors', databasefile=DATABASEFILE_UNITTESTS)
+                                HDWallet.create, 'test_wallet_create_errors', db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError, "Only bip32 or single key scheme's are supported at the moment",
                                 HDWallet.create, 'test_wallet_create_errors2', scheme='raar',
-                                databasefile=DATABASEFILE_UNITTESTS)
+                                db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError, "Wallet name '123' invalid, please include letter characters",
-                                HDWallet.create, '123', databasefile=DATABASEFILE_UNITTESTS)
+                                HDWallet.create, '123', db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError, "Please enter wallet name",
-                                HDWallet.create, '', databasefile=DATABASEFILE_UNITTESTS)
+                                HDWallet.create, '', db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError, "Witness type unknown not supported at the moment",
-                                HDWallet.create, '', witness_type='unknown', databasefile=DATABASEFILE_UNITTESTS)
+                                HDWallet.create, '', witness_type='unknown', db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError, "Multisig wallets should use bip32 scheme not single",
                                 HDWallet.create, 'test_wallet_create_errors_multisig', keys=[HDKey(), HDKey()],
-                                scheme='single', databasefile=DATABASEFILE_UNITTESTS)
+                                scheme='single', db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError, "Password protected multisig wallets not supported",
                                 HDWallet.create, 'test_wallet_create_errors_multisig2', keys=[HDKey(), HDKey()],
-                                password='geheim', databasefile=DATABASEFILE_UNITTESTS)
+                                password='geheim', db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError, "Number of keys required to sign is greater then number of keys provided",
                                 HDWallet.create, 'test_wallet_create_errors_multisig3', keys=[HDKey(), HDKey()],
-                                sigs_required=3, databasefile=DATABASEFILE_UNITTESTS)
+                                sigs_required=3, db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError, ".*\(bitcoin\) is different then network specified: dash",
                                 HDWallet.create, 'test_wallet_create_errors_multisig4',
-                                keys=[HDKey(), HDKey(network='dash')], databasefile=DATABASEFILE_UNITTESTS)
+                                keys=[HDKey(), HDKey(network='dash')], db_uri=self.DATABASE_URI)
         passphrase = 'usual olympic ride small mix follow trend baby stereo sweet lucky lend'
         self.assertRaisesRegexp(WalletError, "Please specify network when using passphrase to create a key",
                                 HDWallet.create, 'test_wallet_create_errors3', keys=passphrase,
-                                databasefile=DATABASEFILE_UNITTESTS)
+                                db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError, "Invalid key or address: zwqrC7h9pRj7SBhLRDG4FnkNBRQgene3y3",
                                 HDWallet.create, 'test_wallet_create_errors4', keys='zwqrC7h9pRj7SBhLRDG4FnkNBRQgene3y3',
-                                databasefile=DATABASEFILE_UNITTESTS)
+                                db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError, "Invalid key or address: zwqrC7h9pRj7SBhLRDG4FnkNBRQgene3y3",
                                 HDWallet.create, 'test_wallet_create_errors4', keys='zwqrC7h9pRj7SBhLRDG4FnkNBRQgene3y3',
-                                databasefile=DATABASEFILE_UNITTESTS)
+                                db_uri=self.DATABASE_URI)
         k = HDKey(network='litecoin').wif_private()
         self.assertRaisesRegexp(BKeyError, "Network bitcoin not found in extracted networks",
                                 HDWallet.create, 'test_wallet_create_errors5', keys=k, network='bitcoin',
-                                databasefile=DATABASEFILE_UNITTESTS)
+                                db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError, "Segwit is not supported for Dash wallets",
                                 HDWallet.create, 'test_wallet_create_errors6', keys=HDKey(network='dash'),
-                                witness_type='segwit', databasefile=DATABASEFILE_UNITTESTS)
+                                witness_type='segwit', db_uri=self.DATABASE_URI)
         k = HDKey().subkey_for_path('m/1/2/3/4/5/6/7')
         self.assertRaisesRegexp(WalletError, "Depth of provided public master key 7 does not correspond with key path",
                                 HDWallet.create, 'test_wallet_create_errors7', keys=k,
-                                databasefile=DATABASEFILE_UNITTESTS)
+                                db_uri=self.DATABASE_URI)
 
     def test_wallet_rename_duplicate(self):
-        HDWallet.create('test_wallet_rename_duplicate1', databasefile=DATABASEFILE_UNITTESTS)
-        w2 = HDWallet.create('test_wallet_rename_duplicate2', databasefile=DATABASEFILE_UNITTESTS)
+        HDWallet.create('test_wallet_rename_duplicate1', db_uri=self.DATABASE_URI)
+        w2 = HDWallet.create('test_wallet_rename_duplicate2', db_uri=self.DATABASE_URI)
 
         def test_func():
             w2.name = 'test_wallet_rename_duplicate1'
         self.assertRaisesRegexp(WalletError, "Wallet with name 'test_wallet_rename_duplicate1' already exists", test_func)
 
 
-class TestWalletImport(unittest.TestCase):
+@parameterized_class(*params)
+class TestWalletImport(TestWalletMixin, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        db_remove()
+        cls.db_remove()
 
     def test_wallet_import(self):
         keystr = 'tprv8ZgxMBicQKsPeWn8NtYVK5Hagad84UEPEs85EciCzf8xYWocuJovxsoNoxZAgfSrCp2xa6DdhDrzYVE8UXF75r2dKePy' \
                  'A7irEvBoe4aAn52'
         wallet_import = HDWallet.create(
-            databasefile=DATABASEFILE_UNITTESTS,
+            db_uri=self.DATABASE_URI,
             name='test_wallet_import',
             network='testnet',
             keys=keystr)
@@ -227,7 +281,7 @@ class TestWalletImport(unittest.TestCase):
         accountkey = 'tprv8h4wEmfC2aSckSCYa68t8MhL7F8p9xAy322B5d6ipzY5ZWGGwksJMoajMCqd73cP4EVRygPQubgJPu9duBzPn3QV' \
                      '8Y7KbKUnaMzx9nnsSvh'
         wallet_import = HDWallet.create(
-            databasefile=DATABASEFILE_UNITTESTS,
+            db_uri=self.DATABASE_URI,
             name='test_wallet_import_account',
             keys=accountkey,
             network='testnet',
@@ -242,7 +296,7 @@ class TestWalletImport(unittest.TestCase):
         accountkey = 'tprv8h4wEmfC2aSckSCYa68t8MhL7F8p9xAy322B5d6ipzY5ZWGGwksJMoajMCqd73cP4EVRygPQubgJPu9duBzPn3QV' \
                      '8Y7KbKUnaMzx9nnsSvh'
         wallet_import = HDWallet.create(
-            databasefile=DATABASEFILE_UNITTESTS,
+            db_uri=self.DATABASE_URI,
             name='test_wallet_import_account_new_key',
             keys=accountkey,
             network='testnet',
@@ -261,7 +315,7 @@ class TestWalletImport(unittest.TestCase):
         pubkey = 'tpubDDkyPBhSAx8DFYxx5aLjvKH6B6Eq2eDK1YN76x1WeijE8eVUswpibGbv8zJjD6yLDHzVcqWzSp2fWVFhEW9XnBssFqMwt' \
                  '9SrsVeBeqfBbR3'
         pubwal = HDWallet.create(
-            databasefile=DATABASEFILE_UNITTESTS,
+            db_uri=self.DATABASE_URI,
             name='test_wallet_import_public_wallet',
             keys=pubkey,
             network='testnet',
@@ -273,7 +327,7 @@ class TestWalletImport(unittest.TestCase):
         accountkey = 'Ltpv71G8qDifUiNet6mn25D7GPAVLZeaFRWzDABxx5xNeigVpFEviHK1ZggPS1kbtegB3U2i8w6ToNfM5sdvEQPW' \
                      'tov4KWyQ5NxWUd3oDWXQb4C'
         wallet_import = HDWallet.create(
-            databasefile=DATABASEFILE_UNITTESTS,
+            db_uri=self.DATABASE_URI,
             name='test_wallet_litecoin',
             keys=accountkey,
             network='litecoin')
@@ -285,19 +339,19 @@ class TestWalletImport(unittest.TestCase):
     def test_wallet_import_key_network_error(self):
         w = HDWallet.create(
             name='Wallet Error',
-            databasefile=DATABASEFILE_UNITTESTS)
+            db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError,
                                 "Network litecoin not available in this wallet, please create an account "
                                 "for this network first.",
-                                w.import_key, 'T43gB4F6k1Ly3YWbMuddq13xLb56hevUDP3RthKArr7FPHjQiXpp', 
+                                w.import_key, 'T43gB4F6k1Ly3YWbMuddq13xLb56hevUDP3RthKArr7FPHjQiXpp',
                                 network='litecoin')
-        
+
     def test_wallet_import_hdwif(self):
         # p2wpkh
         wif = \
             'zpub6s7HTSrGmNUWSgfbDMhYbXVuxA14yNnycS25v6ogicEauzUrRUkuCLQUWbJXP1NyXNqGmwpU6hZw7vr22a4yspwH8XQFjjwRmxC' \
             'KkXdDAXN'
-        w = HDWallet.create("wif_import_p2wpkh", wif, databasefile=DATABASEFILE_UNITTESTS)
+        w = HDWallet.create("wif_import_p2wpkh", wif, db_uri=self.DATABASE_URI)
         self.assertEqual(w.get_key().address, "bc1qruvyu8f2tg06zhysytdsc3qlngnpfzn0juwssx")
         self.assertEqual(w.get_key_change().address, "bc1qg6h45txt82x87uvv3ndm82xsf3wjknq8j7sufh")
 
@@ -305,7 +359,7 @@ class TestWalletImport(unittest.TestCase):
         wif = \
             'ypub6YMgBd4GfQjtxUf8ExorFUQEpBfUYTDz7E1tvfNgDqZeDEUuNNVXSNfsebis2cyeqWYXx6yaBBEQV7sJW3NGoXw5wsp9kkEsB2D' \
             'qiVquYLE'
-        w = HDWallet.create("wif_import_p2sh_p2wpkh", wif, databasefile=DATABASEFILE_UNITTESTS)
+        w = HDWallet.create("wif_import_p2sh_p2wpkh", wif, db_uri=self.DATABASE_URI)
         self.assertEqual(w.get_key().address, "3EFDqEWcrzyidoCXhxaUDB28pVtgX3YuiR")
         self.assertEqual(w.get_key_change().address, "33Un3fDSdT2hsuqyuHiCci1GyUbiyZEWHW")
 
@@ -316,7 +370,7 @@ class TestWalletImport(unittest.TestCase):
         wif2 = \
             'Zpub74JTMKMB9cTWwE9Hs4UVaHvddqPtR51D99x2B5EGyXyxEg3PW77vfmD15RZ86TVdwwwuUaCueBtvaL921mgyKe9Ya6LHCaMXnEp' \
             '1PMw4vDy'
-        w = HDWallet.create("wif_import_p2wsh", [wif1, wif2], databasefile=DATABASEFILE_UNITTESTS)
+        w = HDWallet.create("wif_import_p2wsh", [wif1, wif2], db_uri=self.DATABASE_URI)
         self.assertEqual(w.get_key().address, "bc1qhk5pd2fh0uea8z2wkceuf8eqlxsnkxm0hlt6qvfv346evqnfyumqucpqew")
         self.assertEqual(w.get_key_change().address, "bc1qyn73qh408ry38twxnj4aqzuyv7j6euwhwt2qtzayg673vtw2a4rsn7jlek")
 
@@ -331,14 +385,14 @@ class TestWalletImport(unittest.TestCase):
             'Ypub6jVwyh6yYiRoA5zAnGY1g88G5LdaxkHX65d2kSW97yTBAF1RQwAs3UGPz8bX7LvQfg8tc9MQz7eZ79qVigELqSJzfFbGmPak4PZ' \
             'rvW8fZXy'
         w = HDWallet.create("wif_import_p2sh_p2wsh", [wif1, wif2, wif3], sigs_required=2,
-                            databasefile=DATABASEFILE_UNITTESTS)
+                            db_uri=self.DATABASE_URI)
         self.assertEqual(w.get_key().address, "3BeYQTUgrGPQMHDJcch6mF7G7sRrNYkRhP")
         self.assertEqual(w.get_key_change().address, "3PFD1qkgbaeeDnX38Smerb5vAPBkDVkhcm")
 
     def test_wallet_import_master_key(self):
         k = HDKey()
         w = HDWallet.create('test_wallet_import_master_key', keys=k.public_master(),
-                            databasefile=DATABASEFILE_UNITTESTS)
+                            db_uri=self.DATABASE_URI)
         self.assertFalse(w.main_key.is_private)
         self.assertRaisesRegexp(WalletError, "Please supply a valid private BIP32 master key with key depth 0",
                                 w.import_master_key, k.public())
@@ -352,7 +406,7 @@ class TestWalletImport(unittest.TestCase):
 
         k2 = HDKey()
         w2 = HDWallet.create('test_wallet_import_master_key2', keys=k2.subkey_for_path("m/32'"), scheme='single',
-                             databasefile=DATABASEFILE_UNITTESTS)
+                             db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError, "Main key is already a private key, cannot import key",
                                 w2.import_master_key, k2)
         w2.main_key = None
@@ -361,22 +415,23 @@ class TestWalletImport(unittest.TestCase):
 
         k3 = HDKey()
         w3 = HDWallet.create('test_wallet_import_master_key3', keys=k3.subkey_for_path("m/32'").public(),
-                             scheme='single', databasefile=DATABASEFILE_UNITTESTS)
+                             scheme='single', db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError, "Current main key is not a valid BIP32 public master key",
                                 w3.import_master_key, k3)
 
 
-class TestWalletExport(unittest.TestCase):
+@parameterized_class(*params)
+class TestWalletExport(TestWalletMixin, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        db_remove()
+        cls.db_remove()
 
     def test_wallet_export_hdwifs(self):
         # p2wpkh
         p = 'garage million cheese nephew original subject pass reward month practice advance decide'
         w = HDWallet.create("wif_import_p2wpkh", p, network='bitcoin', witness_type='segwit',
-                            databasefile=DATABASEFILE_UNITTESTS)
+                            db_uri=self.DATABASE_URI)
         wif = 'zpub6s7HTSrGmNUWSgfbDMhYbXVuxA14yNnycS25v6ogicEauzUrRUkuCLQUWbJXP1NyXNqGmwpU6hZw7vr22a4yspwH8XQFjjwRmx' \
               'CKkXdDAXN'
         self.assertEqual(w.account(0).key().wif_public(witness_type=w.witness_type), wif)
@@ -385,7 +440,7 @@ class TestWalletExport(unittest.TestCase):
         # # p2sh_p2wpkh
         p = 'cluster census trash van rack skill feed inflict mixture vocal crew sea'
         w = HDWallet.create("wif_import_p2sh_p2wpkh", p, network='bitcoin', witness_type='p2sh-segwit',
-                            databasefile=DATABASEFILE_UNITTESTS)
+                            db_uri=self.DATABASE_URI)
         wif = 'ypub6YMgBd4GfQjtxUf8ExorFUQEpBfUYTDz7E1tvfNgDqZeDEUuNNVXSNfsebis2cyeqWYXx6yaBBEQV7sJW3NGoXw5wsp9kkEsB2' \
               'DqiVquYLE'
         self.assertEqual(w.wif(is_private=False), wif)
@@ -399,7 +454,7 @@ class TestWalletExport(unittest.TestCase):
             'Zpub74JTMKMB9cTWwE9Hs4UVaHvddqPtR51D99x2B5EGyXyxEg3PW77vfmD15RZ86TVdwwwuUaCueBtvaL921mgyKe9Ya6LHCaMXnEp1'
             'PMw4vDy']
         w = HDWallet.create("wif_import_p2wsh", [p1, p2], witness_type='segwit', network='bitcoin',
-                            databasefile=DATABASEFILE_UNITTESTS)
+                            db_uri=self.DATABASE_URI)
         for wif in w.wif(is_private=False):
             self.assertIn(wif, wifs)
 
@@ -415,24 +470,25 @@ class TestWalletExport(unittest.TestCase):
             'Ypub6jVwyh6yYiRoA5zAnGY1g88G5LdaxkHX65d2kSW97yTBAF1RQwAs3UGPz8bX7LvQfg8tc9MQz7eZ79qVigELqSJzfFbGmPak4PZr'
             'vW8fZXy']
         w = HDWallet.create("wif_import_p2sh_p2wsh", [p1, p2, p3], sigs_required=2, witness_type='p2sh-segwit',
-                            network='bitcoin', databasefile=DATABASEFILE_UNITTESTS)
+                            network='bitcoin', db_uri=self.DATABASE_URI)
         for wif in w.wif(is_private=False):
             self.assertIn(wif, wifs)
 
 
-class TestWalletKeys(unittest.TestCase):
+@parameterized_class(*params)
+class TestWalletKeys(TestWalletMixin, unittest.TestCase):
 
     wallet = None
 
     @classmethod
     def setUpClass(cls):
-        db_remove()
+        cls.db_remove()
         cls.private_wif = 'xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzF9ySUHZw5qJkk5LCALAhXS' \
                            'XoCmCSnStRvgwLBtcbGsg1PeKT2en'
         cls.wallet = HDWallet.create(
             keys=cls.private_wif,
             name='test_wallet_keys',
-            databasefile=DATABASEFILE_UNITTESTS)
+            db_uri=cls.DATABASE_URI)
         cls.wallet.new_key()
         cls.wallet.new_key_change()
 
@@ -470,22 +526,22 @@ class TestWalletKeys(unittest.TestCase):
         self.assertEqual(self.wallet.keys_address_change()[0].address, '13uQKuiWwWp15BsEijnpKZSuTuHVTpZMvP')
 
     def test_wallet_keys_single_key(self):
-        db_remove()
+        self.db_remove()
         wk = 'xprv9s21ZrQH143K3tCgu8uhkA2fw9F9opbvoNNzh5wcuEvNHbCU6Kg3c6dam2a6cw4UYeDxAsgBorAqXp2nsoYS84DqYMwkzxZ15' \
              'ujRHzmBMxE'
-        w = HDWallet.create('test_wallet_keys_single_key', wk, scheme='single', databasefile=DATABASEFILE_UNITTESTS)
+        w = HDWallet.create('test_wallet_keys_single_key', wk, scheme='single', db_uri=self.DATABASE_URI)
         self.assertEqual(w.new_key(), w.new_key())
 
     def test_wallet_create_uncompressed_masterkey(self):
         wlt = wallet_create_or_open('uncompressed_test', keys='68vBWcBndYGLpd4KmeNTk1gS1A71zyDX6uVQKCxq6umYKyYUav5',
-                                    network='bitcoinlib_test', databasefile=DATABASEFILE_UNITTESTS)
+                                    network='bitcoinlib_test', db_uri=self.DATABASE_URI)
         wlt.get_key()
         wlt.utxos_update()
         self.assertIsNone(wlt.sweep('216xtQvbcG4o7Yz33n7VCGyaQhiytuvoqJY').error)
 
     def test_wallet_single_key(self):
         wlt = wallet_create_or_open('single_key', scheme='single', network='bitcoinlib_test',
-                                    databasefile=DATABASEFILE_UNITTESTS)
+                                    db_uri=self.DATABASE_URI)
         wlt.utxos_update()
         transaction = wlt.transaction_create([('21DQCyZTNRoAccG1TWz9YaffDUKzZf6JWii', 90000000)])
         transaction.sign()
@@ -493,12 +549,12 @@ class TestWalletKeys(unittest.TestCase):
 
     def test_wallet_single_key_segwit(self):
         wlt = wallet_create_or_open('single_key_segwit', scheme='single', network='litecoin_testnet',
-                                    witness_type='segwit', databasefile=DATABASEFILE_UNITTESTS)
+                                    witness_type='segwit', db_uri=self.DATABASE_URI)
         self.assertEqual(wlt.addresslist()[0][:5], 'tltc1')
 
     def test_wallet_single_key_main_key(self):
         w = HDWallet.create('multisig_with_single_key', [HDKey().public_master_multisig(), HDKey(key_type='single')],
-                            sigs_required=2, databasefile=DATABASEFILE_UNITTESTS)
+                            sigs_required=2, db_uri=self.DATABASE_URI)
         w.new_key()
         self.assertEqual(len(w.keys_addresses()), 1)
 
@@ -508,7 +564,7 @@ class TestWalletKeys(unittest.TestCase):
         private_hex = 'ffbf97886300c36e747a71d227a3132b209109a9e5296659f5aa03356ca27e1f'
         secret = 115678290018782943471210007860528561263328164009987126706295777426273334361631
         k = HDKey(wif)
-        w = wallet_create_or_open('wlttest', k, databasefile=DATABASEFILE_UNITTESTS)
+        w = wallet_create_or_open('wlttest', k, db_uri=self.DATABASE_URI)
         w_json = w.as_json()
         self.assertFalse(wif in w_json)
         self.assertFalse(private_hex in w_json)
@@ -536,7 +592,7 @@ class TestWalletKeys(unittest.TestCase):
         secret2 = 104285397059777051994770481926675935425657204513917549168323819901909731871228
         k2 = HDKey(wif2)
 
-        wms = wallet_create_or_open('wlttest_ms', [k, k2], databasefile=DATABASEFILE_UNITTESTS)
+        wms = wallet_create_or_open('wlttest_ms', [k, k2], db_uri=self.DATABASE_URI)
         w_json = wms.as_json()
         self.assertFalse('"xprv' in w_json)
         self.assertFalse(wif in w_json)
@@ -549,13 +605,13 @@ class TestWalletKeys(unittest.TestCase):
     def test_wallet_key_create_from_key(self):
         k1 = HDKey(network='dash')
         k2 = HDKey(network='dash')
-        w1 = HDWallet.create('network_mixup_test_wallet', network='litecoin', databasefile=DATABASEFILE_UNITTESTS)
+        w1 = HDWallet.create('network_mixup_test_wallet', network='litecoin', db_uri=self.DATABASE_URI)
         wk1 = HDWalletKey.from_key('key1', w1.wallet_id, w1._session, key=k1.address_obj)
         self.assertEqual(wk1.network.name, 'dash')
         self.assertRaisesRegexp(WalletError, "Specified network and key network should be the same",
                                 HDWalletKey.from_key, 'key2', w1.wallet_id, w1._session, key=k2.address_obj,
                                 network='bitcoin')
-        w2 = HDWallet.create('network_mixup_test_wallet2', network='litecoin', databasefile=DATABASEFILE_UNITTESTS)
+        w2 = HDWallet.create('network_mixup_test_wallet2', network='litecoin', db_uri=self.DATABASE_URI)
         wk2 = HDWalletKey.from_key('key1', w2.wallet_id, w2._session, key=k1)
         self.assertEqual(wk2.network.name, 'dash')
         self.assertRaisesRegexp(WalletError, "Specified network and key network should be the same",
@@ -566,7 +622,7 @@ class TestWalletKeys(unittest.TestCase):
         wk4 = HDWalletKey.from_key('key4', w2.wallet_id, w2._session, key=k1.address_obj)
         self.assertEqual(wk4.name, 'key1')
         k = HDKey().public_master()
-        w = HDWallet.create('pmtest', network='litecoin', databasefile=DATABASEFILE_UNITTESTS)
+        w = HDWallet.create('pmtest', network='litecoin', db_uri=self.DATABASE_URI)
         wk1 = HDWalletKey.from_key('key', w.wallet_id, w._session, key=k)
         self.assertEqual(wk1.path, 'M')
         # Test __repr__ method
@@ -576,23 +632,24 @@ class TestWalletKeys(unittest.TestCase):
         self.assertEqual(wk1.name, 'new_name')
 
     def test_wallet_key_not_found(self):
-        w = HDWallet.create('test_wallet_key_not_found', databasefile=DATABASEFILE_UNITTESTS)
+        w = HDWallet.create('test_wallet_key_not_found', db_uri=self.DATABASE_URI)
         self.assertRaisesRegexp(WalletError, 'Key with id 1000000 not found', HDWalletKey, 1000000, w._session)
 
 
-class TestWalletElectrum(unittest.TestCase):
+@parameterized_class(*params)
+class TestWalletElectrum(TestWalletMixin, unittest.TestCase):
 
     wallet = None
 
     @classmethod
     def setUpClass(cls):
-        db_remove()
+        cls.db_remove()
         cls.pk = 'xprv9s21ZrQH143K2fuscnMTwUadsPqEbYdFQVJ1uWPawUYi7C485NHhCiotGy6Kz3Cz7ReVr65oXNwhREZ8ePrz8p7zy' \
                  'Hra82D1EGS7cQQmreK'
         cls.wallet = HDWallet.create(
             keys=cls.pk,
             name='test_wallet_electrum',
-            databasefile=DATABASEFILE_UNITTESTS)
+            db_uri=cls.DATABASE_URI)
         cls.wallet.key_path = ["m", "change", "address_index"]
         workdir = os.path.dirname(__file__)
         with open('%s/%s' % (workdir, 'electrum_keys.json')) as f:
@@ -612,7 +669,7 @@ class TestWalletElectrum(unittest.TestCase):
     def test_wallet_electrum_p2pkh(self):
         phrase = 'smart donor clever resource stool denial wink under oak sand limb wagon'
         wlt = HDWallet.create('wallet_electrum_p2pkh', phrase, network='bitcoin', witness_type='segwit',
-                              databasefile=DATABASEFILE_UNITTESTS)
+                              db_uri=self.DATABASE_URI)
         self.assertEqual(wlt.get_key().address, 'bc1qjz5l6mej6ptqlggfvdlys8pfukwqp8xnu0mn5u')
         self.assertEqual(wlt.get_key_change().address, 'bc1qz4tr569wfs2fuekgcjtdlz0eufk7rfs8gnu5j9')
 
@@ -620,24 +677,25 @@ class TestWalletElectrum(unittest.TestCase):
         phrase1 = 'magnet voice math okay castle recall arrange music high sustain require crowd'
         phrase2 = 'wink tornado honey delay nest sing series timber album region suit spawn'
         wlt = HDWallet.create('wallet_electrum_p2sh_p2wsh', [phrase1, phrase2], network='bitcoin',
-                              witness_type='p2sh-segwit', databasefile=DATABASEFILE_UNITTESTS)
+                              witness_type='p2sh-segwit', db_uri=self.DATABASE_URI)
         self.assertEqual(wlt.get_key().address, '3ArRVGXfqcjw68XzUZr4iCCemrPoFZxm7s')
         self.assertEqual(wlt.get_key_change().address, '3FZEUFf59C3psUUiKB8TFbjsFUGWD73QPY')
 
 
-class TestWalletMultiCurrency(unittest.TestCase):
+@parameterized_class(*params)
+class TestWalletMultiCurrency(TestWalletMixin, unittest.TestCase):
 
     wallet = None
 
     @classmethod
     def setUpClass(cls):
-        db_remove()
+        cls.db_remove()
         cls.pk = 'xprv9s21ZrQH143K4478MENLXpSXSvJSRYsjD2G3sY7s5sxAGubyujDmt9Qzfd1me5s1HokWGGKW9Uft8eB9dqryybAcFZ5JAs' \
                  'rg84jAVYwKJ8c'
         cls.wallet = HDWallet.create(
             keys=cls.pk, network='dash',
             name='test_wallet_multicurrency',
-            databasefile=DATABASEFILE_UNITTESTS)
+            db_uri=cls.DATABASE_URI)
 
         cls.wallet.new_account(network='litecoin')
         cls.wallet.new_account(network='bitcoin')
@@ -680,18 +738,19 @@ class TestWalletMultiCurrency(unittest.TestCase):
         self.assertRaisesRegexp(WalletError, error_str, self.wallet.import_key, pk_dashtest)
 
 
-class TestWalletMultiNetworksMultiAccount(unittest.TestCase):
+@parameterized_class(*params)
+class TestWalletMultiNetworksMultiAccount(TestWalletMixin, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        db_remove()
+        cls.db_remove()
 
     def test_wallet_multi_networks_send_transaction(self):
         pk = 'tobacco defy swarm leaf flat pyramid velvet pen minor twist maximum extend'
         wallet = HDWallet.create(
             keys=pk, network='bitcoin',
             name='test_wallet_multi_network_multi_account',
-            databasefile=DATABASEFILE_UNITTESTS)
+            db_uri=self.DATABASE_URI)
 
         wallet.new_key()
         acc = wallet.new_account('BCL test home', network='bitcoinlib_test')
@@ -710,7 +769,7 @@ class TestWalletMultiNetworksMultiAccount(unittest.TestCase):
         ltct_addresses = ['mhHhSx66jdXdUPu2A8pXsCBkX1UvHmSkUJ', 'mrdtENj75WUfrJcZuRdV821tVzKA4VtCBf',
                           'mmWFgfG43tnP2SJ8u8UDN66Xm63okpUctk']
         self.assertListEqual(wallet.addresslist(network='testnet'), ltct_addresses)
-        
+
         t = wallet.send_to('21EsLrvFQdYWXoJjGX8LSEGWHFJDzSs2F35', 10000000, account_id=1,
                            network='bitcoinlib_test', fee=1000, offline=False)
         self.assertIsNone(t.error)
@@ -721,13 +780,13 @@ class TestWalletMultiNetworksMultiAccount(unittest.TestCase):
         del wallet
 
     def test_wallet_multi_networks_account_bip44_code_error(self):
-        wlt = HDWallet.create("wallet-bip44-code-error", network='testnet', databasefile=DATABASEFILE_UNITTESTS)
+        wlt = HDWallet.create("wallet-bip44-code-error", network='testnet', db_uri=self.DATABASE_URI)
         error_str = "Can not create new account for network litecoin_testnet with same BIP44 cointype"
         self.assertRaisesRegexp(WalletError, error_str, wlt.new_account, network='litecoin_testnet')
 
     def test_wallet_get_account_defaults(self):
         w = wallet_create_or_open("test_wallet_get_account_defaults", witness_type='segwit',
-                                  databasefile=DATABASEFILE_UNITTESTS)
+                                  db_uri=self.DATABASE_URI)
         w.get_key(network='litecoin', account_id=100)
         network, account_id, account_key = w._get_account_defaults(network='litecoin')
         self.assertEqual(network, 'litecoin')
@@ -735,7 +794,7 @@ class TestWalletMultiNetworksMultiAccount(unittest.TestCase):
         self.assertIn('account', account_key.name)
 
     def test_wallet_update_attributes(self):
-        w = HDWallet.create('test_wallet_set_attributes', databasefile=DATABASEFILE_UNITTESTS)
+        w = HDWallet.create('test_wallet_set_attributes', db_uri=self.DATABASE_URI)
         w.new_account(network='litecoin', account_id=1200)
         owner = 'Satoshi'
         w.owner = owner
@@ -743,24 +802,25 @@ class TestWalletMultiNetworksMultiAccount(unittest.TestCase):
         w.default_account_id = 1200
         del w
 
-        w2 = HDWallet('test_wallet_set_attributes', databasefile=DATABASEFILE_UNITTESTS)
+        w2 = HDWallet('test_wallet_set_attributes', db_uri=self.DATABASE_URI)
         self.assertEqual(w2.owner, owner)
         self.assertEqual(w2.network.name, 'litecoin')
         nk = w2.new_key()
         self.assertEqual(nk.path, "m/44'/2'/1200'/0/1")
 
 
-class TestWalletBitcoinlibTestnet(unittest.TestCase):
+@parameterized_class(*params)
+class TestWalletBitcoinlibTestnet(TestWalletMixin, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        db_remove()
+        cls.db_remove()
 
     def test_wallet_bitcoinlib_testnet_sendto(self):
         w = HDWallet.create(
             network='bitcoinlib_test',
             name='test_wallet_bitcoinlib_testnet_sendto',
-            databasefile=DATABASEFILE_UNITTESTS)
+            db_uri=self.DATABASE_URI)
 
         w.new_key()
         w.utxos_update()
@@ -770,7 +830,7 @@ class TestWalletBitcoinlibTestnet(unittest.TestCase):
         w = HDWallet.create(
             network='bitcoinlib_test',
             name='test_wallet_bitcoinlib_testnet_send_utxos_updated',
-            databasefile=DATABASEFILE_UNITTESTS)
+            db_uri=self.DATABASE_URI)
 
         w.utxos_update()
         self.assertEqual(len(w.utxos()), 2)
@@ -781,7 +841,7 @@ class TestWalletBitcoinlibTestnet(unittest.TestCase):
         w = HDWallet.create(
             network='bitcoinlib_test',
             name='test_wallet_bitcoinlib_testnet_sendto_no_funds_txfee',
-            databasefile=DATABASEFILE_UNITTESTS)
+            db_uri=self.DATABASE_URI)
         w.new_key()
         w.utxos_update()
         balance = w.balance()
@@ -791,7 +851,7 @@ class TestWalletBitcoinlibTestnet(unittest.TestCase):
         w = HDWallet.create(
             network='bitcoinlib_test',
             name='test_wallet_bitcoinlib_testnet_sweep',
-            databasefile=DATABASEFILE_UNITTESTS)
+            db_uri=self.DATABASE_URI)
         w.new_key()
         w.new_key()
         w.new_key()
@@ -802,20 +862,21 @@ class TestWalletBitcoinlibTestnet(unittest.TestCase):
                                 w.sweep, '21DBmFUMQMP7A6KeENXgZQ4wJdSCeGc2zFo')
 
 
-class TestWalletMultisig(unittest.TestCase):
+@parameterized_class(*params)
+class TestWalletMultisig(TestWalletMixin, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        db_remove()
+        cls.db_remove()
 
     def test_wallet_multisig_2_wallets_private_master_plus_account_public(self):
-        db_remove()
+        self.db_remove()
         pk1 = 'tprv8ZgxMBicQKsPdPVdNSEeAhagkU6tUDhUQi8DcCTmJyNLUyU7svTFzXQdkYqNJDEtQ3S2wAspz3K56CMcmMsZ9eXZ2nkNq' \
               'gVxJhMHq3bGJ1X'
         pk1_acc_pub = 'tpubDCZUk9HLxh5gdB9eC8FUxPB1AbZtsSnbvyrAAzsC8x3tiYDgbzyxcngU99rG333jegHG5vJhs11AHcSVkbwrU' \
                       'bYEsPK8vA7E6yFB9qbsTYi'
-        w1 = HDWallet.create(name='test_wallet_create_1', keys=pk1, databasefile=DATABASEFILE_UNITTESTS)
-        w2 = HDWallet.create(name='test_wallet_create_2', keys=pk1_acc_pub, databasefile=DATABASEFILE_UNITTESTS)
+        w1 = HDWallet.create(name='test_wallet_create_1', keys=pk1, db_uri=self.DATABASE_URI)
+        w2 = HDWallet.create(name='test_wallet_create_2', keys=pk1_acc_pub, db_uri=self.DATABASE_URI)
         wk1 = w1.new_key()
         wk2 = w2.new_key()
         self.assertTrue(wk1.is_private)
@@ -823,7 +884,7 @@ class TestWalletMultisig(unittest.TestCase):
         self.assertEqual(wk1.address, wk2.address)
 
     def test_wallet_multisig_create_2_cosigner_wallets(self):
-        db_remove()
+        self.db_remove()
         pk_wif1 = 'tprv8ZgxMBicQKsPdvHCP6VxtFgowj2k7nBJnuRiVWE4DReDFojkLjyqdT8mtR6XJK9dRBcaa3RwvqiKFjsEQVhKfQmHZCCY' \
                   'f4jRTWvJuVuK67n'
         pk_wif2 = 'tprv8ZgxMBicQKsPdkJVWDkqQQAMVYB2usfVs3VS2tBEsFAzjC84M3TaLMkHyJWjydnJH835KHvksS92ecuwwWFEdLAAccwZ' \
@@ -832,16 +893,16 @@ class TestWalletMultisig(unittest.TestCase):
         pk2 = HDKey(pk_wif2, network='testnet')
         wl1 = HDWallet.create('multisig_test_wallet1',
                               [pk_wif1, pk2.subkey_for_path("m/45'").wif_public()],
-                              sigs_required=2, network='testnet', databasefile=DATABASEFILE_UNITTESTS)
+                              sigs_required=2, network='testnet', db_uri=self.DATABASE_URI)
         wl2 = HDWallet.create('multisig_test_wallet2',
                               [pk1.subkey_for_path("m/45'").wif_public(), pk_wif2],
-                              sigs_required=2, network='testnet', databasefile=DATABASEFILE_UNITTESTS)
+                              sigs_required=2, network='testnet', db_uri=self.DATABASE_URI)
         wl1_key = wl1.new_key()
         wl2_key = wl2.new_key(cosigner_id=wl1.cosigner_id)
         self.assertEqual(wl1_key.address, wl2_key.address)
 
     def test_wallet_multisig_bitcoinlib_testnet_transaction_send(self):
-        db_remove()
+        self.db_remove()
 
         key_list = [
             'Pdke4WfXvALPdbrKEfBU9z9BNuRNbv1gRr66BEiZHKcRXDSZQ3gV',
@@ -851,7 +912,7 @@ class TestWalletMultisig(unittest.TestCase):
 
         # Create wallet and generate key
         wl = HDWallet.create_multisig('multisig_test_simple', key_list, sigs_required=2, network='bitcoinlib_test',
-                                      databasefile=DATABASEFILE_UNITTESTS)
+                                      db_uri=self.DATABASE_URI)
         wl.new_key()
 
         # Sign, verify and send transaction
@@ -863,7 +924,7 @@ class TestWalletMultisig(unittest.TestCase):
         self.assertIsNone(t.error)
 
     def test_wallet_multisig_bitcoin_transaction_send_offline(self):
-        db_remove()
+        self.db_remove()
         pk2 = HDKey('e2cbed99ad03c500f2110f1a3c90e0562a3da4ba0cff0e74028b532c3d69d29d')
         key_list = [
             HDKey('e9e5095d3e26643cc4d996efc6cb9a8d8eb55119fdec9fa28a684ba297528067'),
@@ -872,7 +933,7 @@ class TestWalletMultisig(unittest.TestCase):
                 multisig=True).public(),
         ]
         wl = HDWallet.create('multisig_test_bitcoin_send', key_list, sigs_required=2,
-                             databasefile=DATABASEFILE_UNITTESTS)
+                             db_uri=self.DATABASE_URI)
         wl.utxo_add(wl.get_key().address, 200000, '46fcfdbdc3573756916a0ced8bbc5418063abccd2c272f17bf266f77549b62d5', 0)
         t = wl.transaction_create([('3CuJb6XrBNddS79vr27SwqgR4oephY6xiJ', 100000)])
         t.sign(pk2.subkey_for_path("m/45'/2/0/0"))
@@ -881,7 +942,7 @@ class TestWalletMultisig(unittest.TestCase):
         self.assertIsNone(t.error)
 
     def test_wallet_multisig_bitcoin_transaction_send_no_subkey_for_path(self):
-        db_remove()
+        self.db_remove()
         pk2 = HDKey('e2cbed99ad03c500f2110f1a3c90e0562a3da4ba0cff0e74028b532c3d69d29d')
         key_list = [
             HDKey('e9e5095d3e26643cc4d996efc6cb9a8d8eb55119fdec9fa28a684ba297528067'),
@@ -889,7 +950,7 @@ class TestWalletMultisig(unittest.TestCase):
             HDKey('86b77aee5cfc3a55eb0b1099752479d82cb6ebaa8f1c4e9ef46ca0d1dc3847e6').public_master(multisig=True),
         ]
         wl = HDWallet.create('multisig_test_bitcoin_send', key_list, sigs_required=2,
-                             databasefile=DATABASEFILE_UNITTESTS)
+                             db_uri=self.DATABASE_URI)
         wl.utxo_add(wl.get_key().address, 200000, '46fcfdbdc3573756916a0ced8bbc5418063abccd2c272f17bf266f77549b62d5', 0)
         t = wl.transaction_create([('3CuJb6XrBNddS79vr27SwqgR4oephY6xiJ', 100000)])
         t.sign(pk2)
@@ -898,7 +959,7 @@ class TestWalletMultisig(unittest.TestCase):
         self.assertIsNone(t.error)
 
     def test_wallet_multisig_litecoin_transaction_send_offline(self):
-        db_remove()
+        self.db_remove()
         NETWORK = 'litecoin_legacy'
         pk2 = HDKey('e2cbed99ad03c500f2110f1a3c90e0562a3da4ba0cff0e74028b532c3d69d29d', network=NETWORK)
         key_list = [
@@ -908,7 +969,7 @@ class TestWalletMultisig(unittest.TestCase):
                   network=NETWORK).public_master(multisig=True),
         ]
         wl = HDWallet.create('multisig_test_bitcoin_send', key_list, sigs_required=2, network=NETWORK,
-                             databasefile=DATABASEFILE_UNITTESTS)
+                             db_uri=self.DATABASE_URI)
         wl.get_key(number_of_keys=2)
         wl.utxo_add(wl.get_key().address, 200000, '46fcfdbdc3573756916a0ced8bbc5418063abccd2c272f17bf266f77549b62d5', 0)
         t = wl.transaction_create([('3DrP2R8XmHswUyeK9GeYgHJxvyxTfMNkid', 100000)])
@@ -924,7 +985,7 @@ class TestWalletMultisig(unittest.TestCase):
         and verify created transaction.
 
         """
-        db_remove()
+        self.db_remove()
 
         keys = [
             HDKey('YXscyqNJ5YK411nwB4wzazXjJn9L9iLAR1zEMFcpLipDA25rZregBGgwXmprsvQLeQAsuTvemtbCWR1AHaPv2qmvkartoiFUU6'
@@ -934,10 +995,10 @@ class TestWalletMultisig(unittest.TestCase):
 
         msw1 = HDWallet.create('msw1', [keys[0], keys[1].subkey_for_path("m/45'").wif_public()],
                                network='bitcoinlib_test', sort_keys=False, sigs_required=2,
-                               databasefile=DATABASEFILE_UNITTESTS)
+                               db_uri=self.DATABASE_URI)
         msw2 = HDWallet.create('msw2', [keys[0].subkey_for_path("m/45'").wif_public(), keys[1]],
                                network='bitcoinlib_test', sort_keys=False, sigs_required=2,
-                               databasefile=DATABASEFILE_UNITTESTS)
+                               db_uri=self.DATABASE_URI)
         msw1.new_key()
         self.assertEqual(len(msw1.get_key().key()), 2)
         msw2.new_key(cosigner_id=0)
@@ -958,8 +1019,7 @@ class TestWalletMultisig(unittest.TestCase):
         separate databases to check for database interference.
 
         """
-        db_remove()
-        db_remove(DATABASEFILE_UNITTESTS_2)
+        self.db_remove()
 
         keys = [
             HDKey('YXscyqNJ5YK411nwB4wzazXjJn9L9iLAR1zEMFcpLipDA25rZregBGgwXmprsvQLeQAsuTvemtbCWR1AHaPv2qmvkartoiFUU6'
@@ -968,9 +1028,9 @@ class TestWalletMultisig(unittest.TestCase):
                   'wadGhxByT2MnLd', network='bitcoinlib_test')]
 
         msw1 = HDWallet.create('msw1', [keys[0], keys[1].public_master(multisig=True)], network='bitcoinlib_test',
-                               sort_keys=False, sigs_required=2, databasefile=DATABASEFILE_UNITTESTS)
+                               sort_keys=False, sigs_required=2, db_uri=self.DATABASE_URI)
         msw2 = HDWallet.create('msw2', [keys[0].public_master(multisig=True), keys[1]], network='bitcoinlib_test',
-                               sort_keys=False, sigs_required=2, databasefile=DATABASEFILE_UNITTESTS_2)
+                               sort_keys=False, sigs_required=2, db_uri=self.DATABASE_URI_2)
         msw1.new_key()
         msw2.new_key(cosigner_id=msw1.cosigner_id)
         msw1.utxos_update()
@@ -985,8 +1045,8 @@ class TestWalletMultisig(unittest.TestCase):
         t2.send()
         self.assertIsNone(t2.error)
 
-    @staticmethod
-    def _multisig_test(sigs_required, number_of_sigs, sort_keys, network):
+    @classmethod
+    def _multisig_test(cls, sigs_required, number_of_sigs, sort_keys, network):
         # Create Keys
         key_dict = {}
         for key_id in range(number_of_sigs):
@@ -1006,7 +1066,7 @@ class TestWalletMultisig(unittest.TestCase):
                     key_list.append(key_dict[key_id].public_master(multisig=True, as_private=True))
             wallet_dict[wallet_id] = HDWallet.create(
                 wallet_name, key_list, sigs_required=sigs_required, network=network, sort_keys=sort_keys,
-                databasefile=DATABASEFILE_UNITTESTS)
+                db_uri=cls.DATABASE_URI)
             wallet_keys[wallet_id] = wallet_dict[wallet_id].new_key()
             wallet_dict[wallet_id].utxos_update()
 
@@ -1033,34 +1093,34 @@ class TestWalletMultisig(unittest.TestCase):
         return t
 
     def test_wallet_multisig_2of3(self):
-        db_remove()
+        self.db_remove()
         t = self._multisig_test(2, 3, False, 'bitcoinlib_test')
         self.assertTrue(t.verify())
 
     def test_wallet_multisig_2of3_sorted(self):
-        db_remove()
+        self.db_remove()
         t = self._multisig_test(2, 3, True, 'bitcoinlib_test')
         self.assertTrue(t.verify())
 
     def test_wallet_multisig_3of5(self):
-        db_remove()
+        self.db_remove()
         t = self._multisig_test(3, 5, False, 'bitcoinlib_test')
         self.assertTrue(t.verify())
 
     def test_wallet_multisig_2of2_with_single_key(self):
-        db_remove()
+        self.db_remove()
         keys = [HDKey(network='bitcoinlib_test'), HDKey(network='bitcoinlib_test', key_type='single')]
         key_list = [keys[0], keys[1].public()]
 
         wl = HDWallet.create('multisig_expk2', key_list, sigs_required=2, network='bitcoinlib_test',
-                             databasefile=DATABASEFILE_UNITTESTS, sort_keys=False)
-        wl.new_key()
-        wl.new_key()
-        wl.new_key_change()
+                             db_uri=self.DATABASE_URI, sort_keys=False)
+        k1 = wl.new_key()
+        k2 = wl.new_key()
+        k3 = wl.new_key_change()
         wl.utxos_update()
         self.assertEqual(wl.public_master()[1].wif, keys[1].wif())
         key_names = [k.name for k in wl.keys(is_active=False)]
-        self.assertListEqual(key_names, ['Multisig Key 5/6', 'Multisig Key 8/6', 'Multisig Key 11/6'])
+        self.assertListEqual(key_names, [k1.name, k2.name, k3.name])
 
         t = wl.transaction_create([(HDKey(network='bitcoinlib_test').address(), 6400000)], min_confirms=0)
         t.sign(keys[1])
@@ -1068,16 +1128,16 @@ class TestWalletMultisig(unittest.TestCase):
         self.assertIsNone(t.error)
 
     def test_wallet_multisig_sorted_keys(self):
-        db_remove()
+        self.db_remove()
         key1 = HDKey()
         key2 = HDKey()
         key3 = HDKey()
         w1 = HDWallet.create('w1', [key1, key2.public_master(multisig=True), key3.public_master(multisig=True)],
-                             sigs_required=2, databasefile=DATABASEFILE_UNITTESTS)
+                             sigs_required=2, db_uri=self.DATABASE_URI)
         w2 = HDWallet.create('w2', [key1.public_master(multisig=True), key2, key3.public_master(multisig=True)],
-                             sigs_required=2, databasefile=DATABASEFILE_UNITTESTS)
+                             sigs_required=2, db_uri=self.DATABASE_URI)
         w3 = HDWallet.create('w3', [key1.public_master(multisig=True), key2.public_master(multisig=True), key3],
-                             sigs_required=2, databasefile=DATABASEFILE_UNITTESTS)
+                             sigs_required=2, db_uri=self.DATABASE_URI)
         for _ in range(5):
             cosigner_id = random.randint(0, 2)
             address1 = w1.new_key(cosigner_id=cosigner_id).address
@@ -1087,7 +1147,7 @@ class TestWalletMultisig(unittest.TestCase):
                             'Different addressed generated: %s %s %s' % (address1, address2, address3))
 
     def test_wallet_multisig_sign_with_external_single_key(self):
-        db_remove()
+        self.db_remove()
         network = 'bitcoinlib_test'
         words = 'square innocent drama'
         seed = Mnemonic().to_seed(words, 'password')
@@ -1100,7 +1160,7 @@ class TestWalletMultisig(unittest.TestCase):
             hdkey.public()
         ]
         wallet = HDWallet.create('Multisig-2-of-3-example', key_list, sigs_required=2, network=network,
-                                 databasefile=DATABASEFILE_UNITTESTS)
+                                 db_uri=self.DATABASE_URI)
         wallet.new_key()
         wallet.utxos_update()
         wt = wallet.send_to('21A6yyUPRL9hZZo1Rw4qP5G6h9idVVLUncE', 10000000)
@@ -1113,19 +1173,19 @@ class TestWalletMultisig(unittest.TestCase):
         def _open_all_wallets():
             wl1 = wallet_create_or_open(
                 'multisigmulticur1_tst', sigs_required=2, network=network,
-                databasefile=DATABASEFILE_UNITTESTS, sort_keys=False,
+                db_uri=self.DATABASE_URI, sort_keys=False,
                 keys=[pk1, pk2.public_master(), pk3.public_master()])
             wl2 = wallet_create_or_open(
                 'multisigmulticur2_tst', sigs_required=2, network=network,
-                databasefile=DATABASEFILE_UNITTESTS, sort_keys=False,
+                db_uri=self.DATABASE_URI, sort_keys=False,
                 keys=[pk1.public_master(), pk2, pk3.public_master()])
             wl3 = wallet_create_or_open(
                 'multisigmulticur3_tst', sigs_required=2, network=network,
-                databasefile=DATABASEFILE_UNITTESTS, sort_keys=False,
+                db_uri=self.DATABASE_URI, sort_keys=False,
                 keys=[pk1.public_master(), pk2.public_master(), pk3])
             return wl1, wl2, wl3
 
-        db_remove()
+        self.db_remove()
         network = 'litecoin'
         phrase1 = 'shop cloth bench traffic vintage security hour engage omit almost episode fragile'
         phrase2 = 'exclude twice mention orchard grit ignore display shine cheap exercise same apart'
@@ -1142,7 +1202,7 @@ class TestWalletMultisig(unittest.TestCase):
             self.assertEqual(wlt.get_key(cosigner_id=1).address, 'MQVt7KeRHGe35b9ziZo16T5y4fQPg6Up7q')
 
     def test_wallet_multisig_network_mixups(self):
-        db_remove()
+        self.db_remove()
         network = 'litecoin_testnet'
         phrase1 = 'shop cloth bench traffic vintage security hour engage omit almost episode fragile'
         phrase2 = 'exclude twice mention orchard grit ignore display shine cheap exercise same apart'
@@ -1150,7 +1210,7 @@ class TestWalletMultisig(unittest.TestCase):
         pk2 = HDKey.from_passphrase(phrase2, multisig=True, network=network)
         pk3 = HDKey.from_passphrase(phrase3, multisig=True, network=network)
         wlt = wallet_create_or_open(
-            'multisig_network_mixups', sigs_required=2, network=network, databasefile=DATABASEFILE_UNITTESTS,
+            'multisig_network_mixups', sigs_required=2, network=network, db_uri=self.DATABASE_URI,
             keys=[phrase1, pk2.public_master(), pk3.public_master()],
             sort_keys=False)
         self.assertEqual(wlt.get_key().address, 'QjecchURWzhzUzLkhJ8Xijnm29Z9PscSqD')
@@ -1158,16 +1218,17 @@ class TestWalletMultisig(unittest.TestCase):
 
     def test_wallet_multisig_info(self):
         w = HDWallet.create('test_wallet_multisig_info', keys=[HDKey(), HDKey()],
-                            network='bitcoinlib_test', databasefile=DATABASEFILE_UNITTESTS)
+                            network='bitcoinlib_test', db_uri=self.DATABASE_URI)
         w.utxos_update()
         w.info(detail=6)
 
 
-class TestWalletKeyImport(unittest.TestCase):
+@parameterized_class(*params)
+class TestWalletKeyImport(TestWalletMixin, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        db_remove()
+        cls.db_remove()
 
     def test_wallet_key_import_and_sign_multisig(self):
         network = 'bitcoinlib_test'
@@ -1182,7 +1243,7 @@ class TestWalletKeyImport(unittest.TestCase):
             hdkey.public()
         ]
         with HDWallet.create('Multisig-2-of-3-example', key_list, sigs_required=2,
-                             databasefile=DATABASEFILE_UNITTESTS) as wlt:
+                             db_uri=self.DATABASE_URI) as wlt:
             wlt.new_key()
             wlt.utxos_update()
             wt = wlt.send_to('21A6yyUPRL9hZZo1Rw4qP5G6h9idVVLUncE', 10000000)
@@ -1194,7 +1255,7 @@ class TestWalletKeyImport(unittest.TestCase):
         hdkey = HDKey(
             'xprv9s21ZrQH143K2noEZoqGHnaDDLjrnFpis8jm7NWDhkWuNNCqMupGSy7PMYtGL9jvdTY7Nx3GZ6UZ9C52nebwbYXK73imaPUK24'
             'dZJtGZhGd')
-        with HDWallet.create('public-private', hdkey.public_master().public(), databasefile=DATABASEFILE_UNITTESTS) \
+        with HDWallet.create('public-private', hdkey.public_master().public(), db_uri=self.DATABASE_URI) \
                 as wlt:
             self.assertFalse(wlt.main_key.is_private)
             wlt.import_key(hdkey)
@@ -1215,7 +1276,7 @@ class TestWalletKeyImport(unittest.TestCase):
                "iFEwaUv85GA"
 
         with wallet_create_or_open("mstest", [puk1, puk2, puk3], 2, network='litecoin', sort_keys=False,
-                                   databasefile=DATABASEFILE_UNITTESTS) as wlt:
+                                   db_uri=self.DATABASE_URI) as wlt:
             self.assertFalse(wlt.cosigner[2].main_key.is_private)
             wlt.import_key(prk3)
             self.assertTrue(wlt.cosigner[2].main_key.is_private)
@@ -1227,7 +1288,7 @@ class TestWalletKeyImport(unittest.TestCase):
                     'ciEAxk7gLgDkoZC5Lq')
         w = HDWallet.create('segwit-p2sh-p2wsh-import',
                             [pk1, pk2.public_master(witness_type='p2sh-segwit', multisig=True)],
-                            witness_type='p2sh-segwit', network='bitcoinlib_test', databasefile=DATABASEFILE_UNITTESTS)
+                            witness_type='p2sh-segwit', network='bitcoinlib_test', db_uri=self.DATABASE_URI)
         w.get_key()
         w.utxos_update()
         t = w.sweep('23CvEnQKsTVGgqCZzW6ewXPSJH9msFPsBt3')
@@ -1259,7 +1320,7 @@ class TestWalletKeyImport(unittest.TestCase):
         pubk2 = k2.public_master_multisig(witness_type=witness_type)
         self.assertEqual(pubk1.wif(), wif1)
         self.assertEqual(pubk2.wif(), wif2)
-        w = HDWallet.create('mswlt', [p1, pubk2], databasefile=DATABASEFILE_UNITTESTS, witness_type=witness_type)
+        w = HDWallet.create('mswlt', [p1, pubk2], db_uri=self.DATABASE_URI, witness_type=witness_type)
         wk = w.new_key()
         self.assertEqual(wk.address, 'bc1qr7r7zpr5gqnz0zs39ve7c0g54gwe7h7322lt3kae6gh8tzc5epts0j9rhm')
         self.assertFalse(w.public_master(as_private=True)[1].is_private)
@@ -1275,17 +1336,18 @@ class TestWalletKeyImport(unittest.TestCase):
         self.assertListEqual(tx_hashes, tx_hashes_expected)
 
 
-class TestWalletTransactions(unittest.TestCase, CustomAssertions):
+@parameterized_class(*params)
+class TestWalletTransactions(TestWalletMixin, unittest.TestCase, CustomAssertions):
 
     wallet = None
 
     @classmethod
     def setUpClass(cls):
-        db_remove()
+        cls.db_remove()
         account_key = 'tpubDCmJWqxWch7LYDhSuE1jEJMbAkbkDm3DotWKZ69oZfNMzuw7U5DwEaTVZHGPzt5j9BJDoxqVkPHt2EpUF66FrZhpfq' \
                       'ZY6DFj6x61Wwbrg8Q'
         cls.wallet = wallet_create_or_open('utxo-test', keys=account_key, network='testnet',
-                                           databasefile=DATABASEFILE_UNITTESTS)
+                                           db_uri=cls.DATABASE_URI)
         cls.wallet.new_key()
         cls.wallet.utxos_update()
 
@@ -1307,7 +1369,7 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
                     'qjcDhTcyVLhrXXZ'
         hdkey = HDKey(hdkey_wif)
         wlt = wallet_create_or_open('offline-create-transaction', keys=hdkey, network='testnet',
-                                    databasefile=DATABASEFILE_UNITTESTS)
+                                    db_uri=self.DATABASE_URI)
         self.assertEqual(wlt.wif(is_private=True), hdkey_wif)
         wlt.get_key()
         utxos = [{
@@ -1328,14 +1390,14 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
         account_key = 'tpubDCmJWqxWch7LYDhSuE1jEJMbAkbkDm3DotWKZ69oZfNMzuw7U5DwEaTVZHGPzt5j9BJDoxqVkPHt2EpUF66FrZhpfq' \
                       'ZY6DFj6x61Wwbrg8Q'
         self.wallet = wallet_create_or_open('scan-test', keys=account_key, network='testnet',
-                                            databasefile=DATABASEFILE_UNITTESTS)
+                                            db_uri=self.DATABASE_URI)
         self.wallet.scan(scan_gap_limit=10)
         self.assertEqual(len(self.wallet.keys()), 25)
         self.assertEqual(len(self.wallet.keys(is_active=None)), 31)
         self.assertEqual(self.wallet.balance(), 60500000)
 
     def test_wallet_two_utxos_one_key(self):
-        wlt = HDWallet.create('double-utxo-test', network='bitcoinlib_test', databasefile=DATABASEFILE_UNITTESTS)
+        wlt = HDWallet.create('double-utxo-test', network='bitcoinlib_test', db_uri=self.DATABASE_URI)
         key = wlt.new_key()
         wlt.utxos_update()
         utxos = wlt.utxos()
@@ -1352,7 +1414,7 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
         del wlt
 
     def test_wallet_balance_update(self):
-        wlt = HDWallet.create('test-balance-update', network='bitcoinlib_test', databasefile=DATABASEFILE_UNITTESTS)
+        wlt = HDWallet.create('test-balance-update', network='bitcoinlib_test', db_uri=self.DATABASE_URI)
         to_key = wlt.get_key()
         wlt.utxos_update()
         self.assertEqual(wlt.balance(), 200000000)
@@ -1365,7 +1427,7 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
         k = "tpubDCutwJADa3iSbFtB2LgnaaqJgZ8FPXRRzcrMq7Tms41QNnTV291rpkps9vRwyss9zgDc7hS5V1aM1by8nFip5VjpGpz1oP54peKt" \
             "hJzfabX"
         wlt = HDWallet.create("test_wallet_balance_update_multi_network", network='bitcoinlib_test',
-                              databasefile=DATABASEFILE_UNITTESTS)
+                              db_uri=self.DATABASE_URI)
         wlt.new_key()
         wlt.new_account(network='testnet')
         wlt.import_key(k)
@@ -1379,13 +1441,13 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
         k = "tpubDCutwJADa3iSbFtB2LgnaaqJgZ8FPXRRzcrMq7Tms41QNnTV291rpkps9vRwyss9zgDc7hS5V1aM1by8nFip5VjpGpz1oP54peKt" \
             "hJzfabX"
         wlt = HDWallet.create("test_wallet_balance_update_total", keys=k, network='testnet',
-                              databasefile=DATABASEFILE_UNITTESTS)
+                              db_uri=self.DATABASE_URI)
         wlt.get_key()
         self.assertEqual(wlt.balance_update_from_serviceprovider(), 900)
 
     def test_wallet_add_dust_to_fee(self):
         # Send bitcoinlib test transaction and check if dust resume amount is added to fee
-        wlt = HDWallet.create('bcltestwlt', network='bitcoinlib_test', databasefile=DATABASEFILE_UNITTESTS)
+        wlt = HDWallet.create('bcltestwlt', network='bitcoinlib_test', db_uri=self.DATABASE_URI)
         to_key = wlt.get_key()
         wlt.utxos_update()
         t = wlt.send_to(to_key.address, 99992000)
@@ -1394,7 +1456,7 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
 
     def test_wallet_transactions_send_update_utxos(self):
         # Send bitcoinlib test transaction and check if all utxo's are updated after send
-        wlt = HDWallet.create('bcltestwlt2', network='bitcoinlib_test', databasefile=DATABASEFILE_UNITTESTS)
+        wlt = HDWallet.create('bcltestwlt2', network='bitcoinlib_test', db_uri=self.DATABASE_URI)
         to_key = wlt.get_key(number_of_keys=5)
         wlt.utxos_update()
         self.assertEqual(wlt.balance(), 1000000000)
@@ -1405,7 +1467,7 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
         del wlt
 
     def test_wallet_transaction_import(self):
-        wlt = HDWallet.create('bcltestwlt3', network='bitcoinlib_test', databasefile=DATABASEFILE_UNITTESTS)
+        wlt = HDWallet.create('bcltestwlt3', network='bitcoinlib_test', db_uri=self.DATABASE_URI)
         to_key = wlt.get_key()
         wlt.utxos_update()
         t = wlt.send_to(to_key.address, 50000000, offline=True)
@@ -1414,7 +1476,7 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
         del wlt
 
     def test_wallet_transaction_import_raw(self):
-        wlt = HDWallet.create('bcltestwlt4', network='bitcoinlib_test', databasefile=DATABASEFILE_UNITTESTS)
+        wlt = HDWallet.create('bcltestwlt4', network='bitcoinlib_test', db_uri=self.DATABASE_URI)
         to_key = wlt.get_key()
         wlt.utxos_update()
         t = wlt.send_to(to_key.address, 50000000, offline=True)
@@ -1423,7 +1485,7 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
         del wlt
 
     def test_wallet_transaction_fee_limits(self):
-        wlt = HDWallet.create('bcltestwlt5', network='bitcoinlib_test', databasefile=DATABASEFILE_UNITTESTS)
+        wlt = HDWallet.create('bcltestwlt5', network='bitcoinlib_test', db_uri=self.DATABASE_URI)
         to_key = wlt.get_key()
         wlt.utxos_update()
         self.assertRaisesRegexp(WalletError, 'Fee per kB of 682 is lower then minimal network fee of 1000',
@@ -1432,7 +1494,7 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
                                 wlt.send_to, to_key.address, 50000000, fee=300000)
 
     def test_wallet_transaction_fee_zero_problem(self):
-        wlt = HDWallet.create(name='bcltestwlt6', network='bitcoinlib_test', databasefile=DATABASEFILE_UNITTESTS)
+        wlt = HDWallet.create(name='bcltestwlt6', network='bitcoinlib_test', db_uri=self.DATABASE_URI)
         nk = wlt.get_key()
         wlt.utxos_update()
         t = wlt.send_to(nk.address, 100000000)
@@ -1443,9 +1505,9 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
         prev_tx_hash = '46fcfdbdc3573756916a0ced8bbc5418063abccd2c272f17bf266f77549b62d5'
 
         for witness_type in ['legacy', 'p2sh-segwit', 'segwit']:
-            wallet_delete_if_exists('wallet_estimate_size', force=True, databasefile=DATABASEFILE_UNITTESTS)
+            wallet_delete_if_exists('wallet_estimate_size', force=True, db_uri=self.DATABASE_URI)
             wl3 = HDWallet.create('wallet_estimate_size', witness_type=witness_type,
-                                  databasefile=DATABASEFILE_UNITTESTS)
+                                  db_uri=self.DATABASE_URI)
             wl3.utxo_add(wl3.get_key().address, 110000, prev_tx_hash, 0)
             to_address = wl3.get_key_change().address
             t = wl3.transaction_create([(to_address, 90000)], fee=10000)
@@ -1462,9 +1524,9 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
             p2 = HDKey(witness_type=witness_type, multisig=True)
             p3 = HDKey(witness_type=witness_type, multisig=True)
 
-            wallet_delete_if_exists('wallet_estimate_size_multisig', force=True, databasefile=DATABASEFILE_UNITTESTS)
+            wallet_delete_if_exists('wallet_estimate_size_multisig', force=True, db_uri=self.DATABASE_URI)
             wl3 = HDWallet.create('wallet_estimate_size_multisig', [p1, p2.public_master(), p3.public_master()],
-                                  sigs_required=2, databasefile=DATABASEFILE_UNITTESTS)
+                                  sigs_required=2, db_uri=self.DATABASE_URI)
             wl3.utxo_add(wl3.get_key().address, 110000, prev_tx_hash, 0)
             to_address = wl3.get_key_change().address
             t = wl3.transaction_create([(to_address, 90000)], fee=10000)
@@ -1479,7 +1541,7 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
     def test_wallet_transaction_method(self):
         pk1 = HDKey(network='bitcoinlib_test')
         pk2 = HDKey(network='bitcoinlib_test')
-        w = HDWallet.create('wallet_transaction_tests', keys=[pk1, pk2], databasefile=DATABASEFILE_UNITTESTS)
+        w = HDWallet.create('wallet_transaction_tests', keys=[pk1, pk2], db_uri=self.DATABASE_URI)
         w.get_key()
         w.utxos_update()
         self.assertEqual(len(w.transactions()), 2)
@@ -1488,7 +1550,7 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
 
     def test_wallet_transaction_from_txid(self):
         w = HDWallet.create('testwltbcl', keys='dda84e87df25f32d73a7f7d008ed2b89fc00d9d07fde588d1b8af0af297023de',
-                            network='bitcoinlib_test', databasefile=DATABASEFILE_UNITTESTS)
+                            network='bitcoinlib_test', db_uri=self.DATABASE_URI)
         w.utxos_update()
         wts = w.transactions()
         txid = wts[0].hash
@@ -1506,7 +1568,7 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
     def test_wallet_transaction_sign_with_hex(self):
         k = HDKey(network='bitcoinlib_test')
         pmk = k.public_master()
-        w = HDWallet.create('wallet_tx_tests', keys=pmk, network='bitcoinlib_test', databasefile=DATABASEFILE_UNITTESTS)
+        w = HDWallet.create('wallet_tx_tests', keys=pmk, network='bitcoinlib_test', db_uri=self.DATABASE_URI)
         w.utxos_update()
         wt = w.transaction_create([(w.get_key(), 190000000)])
         sk = k.subkey_for_path("m/44'/9999999'/0'/0/0")
@@ -1521,7 +1583,7 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
         w = wallet_create_or_open('test_wallet_transaction_sign_with_wif',
                                   keys=[wif, HDKey(wif2).public_master_multisig(witness_type='segwit')],
                                   witness_type='segwit', network='bitcoinlib_test',
-                                  databasefile=DATABASEFILE_UNITTESTS)
+                                  db_uri=self.DATABASE_URI)
         w.get_key()
         w.utxos_update()
         t = w.send_to('blt1q285vnphcs4r0t5dw06tmxl7aryj3jnx88duehv4p7eldsshrmygsmlq84z', 2000, fee=1000)
@@ -1531,15 +1593,15 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
 
     def test_wallet_transaction_restore_saved_tx(self):
         w = wallet_create_or_open('test_wallet_transaction_restore', network='bitcoinlib_test',
-                                  databasefile=DATABASEFILE_UNITTESTS)
+                                  db_uri=self.DATABASE_URI)
         w.get_key(number_of_keys=2)
         w.utxos_update()
         to = w.get_key_change()
         t = w.sweep(to.address, offline=True)
         tx_id = t.save()
-        wallet_empty('test_wallet_transaction_restore', databasefile=DATABASEFILE_UNITTESTS)
+        wallet_empty('test_wallet_transaction_restore', db_uri=self.DATABASE_URI)
         w = wallet_create_or_open('test_wallet_transaction_restore', network='bitcoinlib_test',
-                                  databasefile=DATABASEFILE_UNITTESTS)
+                                  db_uri=self.DATABASE_URI)
         w.get_key(number_of_keys=2)
         w.utxos_update()
         to = w.get_key_change()
@@ -1548,7 +1610,7 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
 
     def test_wallet_transaction_send_keyid(self):
         w = HDWallet.create('wallet_send_key_id', witness_type='segwit', network='bitcoinlib_test',
-                            databasefile=DATABASEFILE_UNITTESTS)
+                            db_uri=self.DATABASE_URI)
         keys = w.get_key(number_of_keys=2)
         w.utxos_update()
         t = w.send_to('blt1qtk5swtntg8gvtsyr3kkx3mjcs5ncav84exjvde', 150000000, input_key_id=keys[1].key_id)
@@ -1559,7 +1621,7 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
 
     def test_wallet_transactions_max_txs(self):
         address = '15yN7NPEpu82sHhB6TzCW5z5aXoamiKeGy'
-        w = wallet_create_or_open('ftrtxtstwlt', address, databasefile=DATABASEFILE_UNITTESTS)
+        w = wallet_create_or_open('ftrtxtstwlt', address, db_uri=self.DATABASE_URI)
         w.transactions_update(max_txs=2)
         self.assertGreaterEqual(w.balance(), 5000010000)
         self.assertGreaterEqual(len(w.transactions()), 2)
@@ -1567,16 +1629,17 @@ class TestWalletTransactions(unittest.TestCase, CustomAssertions):
         self.assertGreaterEqual(len(w.transactions()), 4)
 
 
-class TestWalletDash(unittest.TestCase):
+@parameterized_class(*params)
+class TestWalletDash(TestWalletMixin, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        db_remove()
+        cls.db_remove()
 
     def test_wallet_create_with_passphrase_dash(self):
         passphrase = "always reward element perfect chunk father margin slab pond suffer episode deposit"
         wlt = HDWallet.create("wallet-passphrase-litecoin", keys=passphrase, network='dash',
-                              databasefile=DATABASEFILE_UNITTESTS)
+                              db_uri=self.DATABASE_URI)
         keys = wlt.get_key(number_of_keys=5)
         self.assertEqual(keys[4].address, "XhxXcRvTm4yZZzbH4MYz2udkdHWEMMf9GM")
 
@@ -1584,7 +1647,7 @@ class TestWalletDash(unittest.TestCase):
         accountkey = 'xprv9yQgG6Z38AXWuhkxScDCkLzThWWZgDKHKinMHUAPTH1uihrBWQw99sWBsN2HMpzeTze1YEYb8acT1x7sHKhXX8AbT' \
                      'GNf8tdbycySUi2fRaa'
         wallet = HDWallet.create(
-            databasefile=DATABASEFILE_UNITTESTS,
+            db_uri=self.DATABASE_URI,
             name='test_wallet_import_dash',
             keys=accountkey,
             network='dash')
@@ -1598,9 +1661,9 @@ class TestWalletDash(unittest.TestCase):
         pk1 = HDKey(network=network)
         pk2 = HDKey(network=network)
         wl1 = HDWallet.create('multisig_test_wallet1', [pk1, pk2.public_master(multisig=True)], sigs_required=2,
-                              databasefile=DATABASEFILE_UNITTESTS)
+                              db_uri=self.DATABASE_URI)
         wl2 = HDWallet.create('multisig_test_wallet2', [pk1.public_master(multisig=True), pk2], sigs_required=2,
-                              databasefile=DATABASEFILE_UNITTESTS)
+                              db_uri=self.DATABASE_URI)
         wl1_key = wl1.new_key()
         wl2_key = wl2.new_key(cosigner_id=wl1.cosigner_id)
         self.assertEqual(wl1_key.address, wl2_key.address)
@@ -1612,22 +1675,23 @@ class TestWalletDash(unittest.TestCase):
         pk3 = HDKey(network=network)
         with wallet_create_or_open("mstest_dash", [pk1.public_master(multisig=True), pk2.public_master(multisig=True),
                                                    pk3.public_master(multisig=True)], 2, network=network,
-                                   sort_keys=False, databasefile=DATABASEFILE_UNITTESTS) as wlt:
+                                   sort_keys=False, db_uri=self.DATABASE_URI) as wlt:
             self.assertFalse(wlt.cosigner[1].main_key.is_private)
             wlt.import_key(pk2)
             self.assertTrue(wlt.cosigner[1].main_key.is_private)
 
 
-class TestWalletSegwit(unittest.TestCase):
+@parameterized_class(*params)
+class TestWalletSegwit(TestWalletMixin, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        db_remove()
+        cls.db_remove()
 
     def test_wallet_segwit_create_p2pkh(self):
         phrase = 'depth child sheriff attack when purpose velvet stay problem lock myself praise'
         wlt = wallet_create_or_open('thetestwallet-bech32', keys=phrase, network='bitcoin', witness_type='segwit',
-                                    databasefile=DATABASEFILE_UNITTESTS)
+                                    db_uri=self.DATABASE_URI)
         self.assertEqual(wlt.get_key().address, 'bc1q0xjnzddk8t4rnujmya8zgvxuct5s04my0fde3e')
 
     def test_wallet_segwit_create_pswsh(self):
@@ -1636,7 +1700,7 @@ class TestWalletSegwit(unittest.TestCase):
         pk1 = HDKey.from_passphrase(phrase1, witness_type='segwit', multisig=True)
         pk2 = HDKey.from_passphrase(phrase2, witness_type='segwit', multisig=True)
         w = HDWallet.create('multisig-segwit', [pk1, pk2.public_master()], sigs_required=1, witness_type='segwit',
-                            databasefile=DATABASEFILE_UNITTESTS)
+                            db_uri=self.DATABASE_URI)
         self.assertEqual(w.get_key().address, 'bc1qfjhmzzt9l6dmm0xx3tc6qrtff8dve7j7qrcyp88tllszm97r84aqxel5jk')
 
     def test_wallet_segwit_create_p2sh_p2wsh(self):
@@ -1645,7 +1709,7 @@ class TestWalletSegwit(unittest.TestCase):
         pk1 = HDKey.from_passphrase(phrase1)
         pk2 = HDKey.from_passphrase(phrase2)
         w = HDWallet.create('segwit-p2sh-p2wsh', [pk1, pk2.public_master(witness_type='p2sh-segwit', multisig=True)],
-                            sigs_required=2, witness_type='p2sh-segwit', databasefile=DATABASEFILE_UNITTESTS)
+                            sigs_required=2, witness_type='p2sh-segwit', db_uri=self.DATABASE_URI)
         nk = w.get_key()
         self.assertEqual(nk.address, '3JFyRjKWYFz5BMFHLZvT7EZQJ85gLFvtkT')
         self.assertEqual(nk.key_type, 'multisig')
@@ -1654,7 +1718,7 @@ class TestWalletSegwit(unittest.TestCase):
     def test_wallet_segwit_create_p2sh_p2wpkh(self):
         phrase = 'fun brick apology sport museum vague once gospel walnut jump spawn hedgehog'
         w = wallet_create_or_open('segwit-p2sh-p2wpkh', phrase, purpose=49, witness_type='p2sh-segwit',
-                                  network='bitcoin', databasefile=DATABASEFILE_UNITTESTS)
+                                  network='bitcoin', db_uri=self.DATABASE_URI)
 
         k1 = w.get_key()
         address = '3Disr2CmERuYuuMkkfGrjRUHqDENQvtNep'
@@ -1664,7 +1728,7 @@ class TestWalletSegwit(unittest.TestCase):
 
     def test_wallet_segwit_p2wpkh_send(self):
         w = HDWallet.create('segwit_p2wpkh_send', witness_type='segwit', network='bitcoinlib_test',
-                            databasefile=DATABASEFILE_UNITTESTS)
+                            db_uri=self.DATABASE_URI)
         w.get_key()
         w.utxos_update()
         t = w.send_to('blt1q7ywlg3lsyntsmp74jh65pnkntk3csagdwpz78k', 10000)
@@ -1677,7 +1741,7 @@ class TestWalletSegwit(unittest.TestCase):
     def test_wallet_segwit_p2wsh_send(self):
         w = HDWallet.create('segwit_p2wsh_send', witness_type='segwit', network='bitcoinlib_test',
                             keys=[HDKey(network='bitcoinlib_test'), HDKey(network='bitcoinlib_test')], sigs_required=2,
-                            databasefile=DATABASEFILE_UNITTESTS)
+                            db_uri=self.DATABASE_URI)
         w.get_key()
         w.utxos_update()
         t = w.send_to('blt1q7r60he62p52u6h9zyxl6ew4dmmshpmk5sluaax48j9c7zyxu6m0smrjqxa', 10000)
@@ -1689,7 +1753,7 @@ class TestWalletSegwit(unittest.TestCase):
 
     def test_wallet_segwit_p2sh_p2wpkh_send(self):
         w = HDWallet.create('segwit_p2sh_p2wpkh_send', witness_type='p2sh-segwit', network='bitcoinlib_test',
-                            databasefile=DATABASEFILE_UNITTESTS)
+                            db_uri=self.DATABASE_URI)
         w.get_key()
         w.utxos_update()
         t = w.send_to('blt1q7ywlg3lsyntsmp74jh65pnkntk3csagdwpz78k', 10000)
@@ -1703,7 +1767,7 @@ class TestWalletSegwit(unittest.TestCase):
         w = HDWallet.create('segwit_p2sh_p2wsh_send', witness_type='p2sh-segwit', network='bitcoinlib_test',
                             keys=[HDKey(network='bitcoinlib_test'), HDKey(network='bitcoinlib_test'),
                                   HDKey(network='bitcoinlib_test')], sigs_required=2,
-                            databasefile=DATABASEFILE_UNITTESTS)
+                            db_uri=self.DATABASE_URI)
         w.get_key()
         w.utxos_update()
         t = w.send_to('blt1q7ywlg3lsyntsmp74jh65pnkntk3csagdwpz78k', 10000)
@@ -1717,7 +1781,7 @@ class TestWalletSegwit(unittest.TestCase):
         k = HDKey(compressed=False)
         self.assertRaisesRegexp(BKeyError, 'Uncompressed keys are non-standard', wallet_create_or_open,
                                 'segwit_uncompressed_error', k, witness_type='segwit', network='bitcoinlib_test',
-                                databasefile=DATABASEFILE_UNITTESTS)
+                                db_uri=self.DATABASE_URI)
 
     def test_wallet_segwit_bitcoin_send(self):
         # Create several SegWit wallet and create transaction to send to each other. Uses utxo_add() method to create
@@ -1734,7 +1798,7 @@ class TestWalletSegwit(unittest.TestCase):
         ]
 
         wl1 = HDWallet.create('segwit_bitcoin_p2wsh_send', key_list, sigs_required=2, witness_type='segwit',
-                              databasefile=DATABASEFILE_UNITTESTS)
+                              db_uri=self.DATABASE_URI)
         wl1.utxo_add(wl1.get_key().address, 10000000, prev_tx_hash, 0)
         to_address = wl1.get_key_change().address
         t = wl1.transaction_create([(to_address, 100000)], fee=10000)
@@ -1745,7 +1809,7 @@ class TestWalletSegwit(unittest.TestCase):
         self.assertFalse(t.error)
 
         # === Segwit P2WPKH to P2WSH ===
-        wl2 = HDWallet.create('segwit_bitcoin_p2wpkh_send', witness_type='segwit', databasefile=DATABASEFILE_UNITTESTS)
+        wl2 = HDWallet.create('segwit_bitcoin_p2wpkh_send', witness_type='segwit', db_uri=self.DATABASE_URI)
         wl2.utxo_add(wl2.get_key().address, 200000, prev_tx_hash, 0)
         to_address = wl1.get_key_change().address
         t = wl2.transaction_create([(to_address, 100000)], fee=10000)
@@ -1756,7 +1820,7 @@ class TestWalletSegwit(unittest.TestCase):
 
         # === Segwit P2SH-P2WPKH to P2WPK ===
         wl3 = HDWallet.create('segwit_bitcoin_p2sh_p2wpkh_send', witness_type='p2sh-segwit',
-                              databasefile=DATABASEFILE_UNITTESTS)
+                              db_uri=self.DATABASE_URI)
         wl3.utxo_add(wl3.get_key().address, 110000, prev_tx_hash, 0)
         t = wl3.transaction_create([(to_address, 100000)], fee=10000)
         t.sign()
@@ -1767,7 +1831,7 @@ class TestWalletSegwit(unittest.TestCase):
     def test_wallet_segwit_litecoin_multi_accounts(self):
         phrase = 'rug rebuild group coin artwork degree basic humor flight away praise able'
         w = HDWallet.create('segwit_wallet_litecoin_p2wpkh', keys=phrase, network='litecoin',
-                            databasefile=DATABASEFILE_UNITTESTS, witness_type='segwit')
+                            db_uri=self.DATABASE_URI, witness_type='segwit')
         self.assertEqual(w.get_key().address, "ltc1qsrzxzg39jyt8knsw5hlqmpwmuc8ejxvp9hfch8")
         self.assertEqual(w.get_key_change().address, "ltc1q9n6zknsw2hhq7dkyvczars8vl8zta5yusjjem5")
         acc2 = w.new_account()
@@ -1779,14 +1843,14 @@ class TestWalletSegwit(unittest.TestCase):
         phrase = 'rug rebuild group coin artwork degree basic humor flight away praise able'
 
         w = HDWallet.create('segwit_wallet_litecoin_p2sh_p2wpkh', keys=phrase, network='litecoin',
-                            databasefile=DATABASEFILE_UNITTESTS, witness_type='p2sh-segwit')
+                            db_uri=self.DATABASE_URI, witness_type='p2sh-segwit')
         self.assertEqual(w.get_key().address, "MW1V5XPPW1YYQ5BGL5mSWEZNZSyD4XQPgh")
         self.assertEqual(w.get_key_change().address, "MWQoYMDTNvwZPNNypLMzkQ7JNSCtvS554j")
 
     def test_wallet_segwit_litecoin_sweep(self):
         phrase = 'wagon tunnel garage blast eager jaguar shop bring lake dumb chalk emerge'
         w = wallet_create_or_open('ltcsw', phrase, network='litecoin', witness_type='segwit',
-                                  databasefile=DATABASEFILE_UNITTESTS)
+                                  db_uri=self.DATABASE_URI)
         w.utxo_add('ltc1qu8dum66gd6dfr2cchgenf87qqxgenyme2kyhn8', 28471723,
                    '21da13be453624cf46b3d883f39602ce74d04efa7a186037898b6d7bcfd405ee', 10, 99)
         t = w.sweep('MLqham8sXULvktmNMuDQdrBbHRdytVZ1QK', offline=True)
@@ -1796,7 +1860,7 @@ class TestWalletSegwit(unittest.TestCase):
         p1 = 'only sing document speed outer gauge stand govern way column material odor'
         p2 = 'oyster pelican debate mass scene title pipe lock recipe flavor razor accident'
         w = wallet_create_or_open('ltcswms', [p1, p2], network='litecoin', witness_type='segwit',
-                                  databasefile=DATABASEFILE_UNITTESTS)
+                                  db_uri=self.DATABASE_URI)
         w.get_key(number_of_keys=2)
         w.utxo_add('ltc1qkewaz7lxn75y6wppvqlsfhrnq5p5mksmlp26n8xsef0556cdfzqq2uhdrt', 2100000000000001,
                    '21da13be453624cf46b3d883f39602ce74d04efa7a186037898b6d7bcfd405ee', 0, 15)
@@ -1809,7 +1873,7 @@ class TestWalletSegwit(unittest.TestCase):
         cosigner = HDKey(network='bitcoinlib_test')
         w = wallet_create_or_open('test_wallet_segwit_multisig_multiple_inputs',
                                   [main_key, cosigner.public_master(witness_type='segwit', multisig=True)],
-                                  witness_type='segwit', network='bitcoinlib_test', databasefile=DATABASEFILE_UNITTESTS)
+                                  witness_type='segwit', network='bitcoinlib_test', db_uri=self.DATABASE_URI)
 
         w.get_key(number_of_keys=2)
         w.utxos_update()
@@ -1826,7 +1890,7 @@ class TestWalletSegwit(unittest.TestCase):
             "ZprvAhadJRUYsNgeBbjftwKvAhDEV1hrYBGY19wATHqnEt5jfWXxXChYP8Qfnw3w2zJZskNercma5S1fWYH7e7XwbTVPgbabvs1CfU"
             "zY2KQD2cB")
         w = HDWallet.create("account-test", keys=[pk1, pk2.public_master(multisig=True)], witness_type='segwit',
-                            databasefile=DATABASEFILE_UNITTESTS)
+                            db_uri=self.DATABASE_URI)
         w.new_account()
         w.new_account()
         w.new_account(account_id=100)
@@ -1841,7 +1905,7 @@ class TestWalletSegwit(unittest.TestCase):
         pk1 = 'surround vacant shoot aunt acoustic liar barely you expand rug industry grain'
         pk2 = 'defy push try brush ceiling sugar film present goat settle praise toilet'
         wallet = HDWallet.create(keys=[pk1, pk2], network='bitcoin', name='test_wallet_multicurrency',
-                                 witness_type='segwit', databasefile=DATABASEFILE_UNITTESTS, encoding='base58')
+                                 witness_type='segwit', db_uri=self.DATABASE_URI, encoding='base58')
         wallet.new_account(network='litecoin')
         wallet.new_account(network='litecoin')
         wallet.new_account(network='bitcoin')
@@ -1859,14 +1923,15 @@ class TestWalletSegwit(unittest.TestCase):
         self.assertEqual(wallet.keys(network='bitcoin')[0].address, "3L6XFzC6RPeXSFpZS8v4S86v4gsNmKFnFT")
 
 
-class TestWalletKeyStructures(unittest.TestCase):
+@parameterized_class(*params)
+class TestWalletKeyStructures(TestWalletMixin, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        db_remove()
+        cls.db_remove()
 
     def test_wallet_path_expand(self):
-        wlt = wallet_create_or_open('wallet_path_expand', network='bitcoin', databasefile=DATABASEFILE_UNITTESTS)
+        wlt = wallet_create_or_open('wallet_path_expand', network='bitcoin', db_uri=self.DATABASE_URI)
         self.assertListEqual(wlt.path_expand([8]), ['m', "44'", "0'", "0'", '0', '8'])
         self.assertListEqual(wlt.path_expand(['8']), ['m', "44'", "0'", "0'", '0', '8'])
         self.assertListEqual(wlt.path_expand(["99'", 1, 2]), ['m', "44'", "0'", "99'", '1', '2'])
@@ -1884,7 +1949,7 @@ class TestWalletKeyStructures(unittest.TestCase):
 
     def test_wallet_exotic_key_paths(self):
         w = HDWallet.create("simple_custom_keypath", key_path="m/change/address_index",
-                            databasefile=DATABASEFILE_UNITTESTS)
+                            db_uri=self.DATABASE_URI)
         self.assertEqual(w.new_key().path, "m/0/1")
         self.assertEqual(w.new_key_change().path, "m/1/0")
         self.assertEqual(w.wif()[:4], 'xpub')
@@ -1892,7 +1957,7 @@ class TestWalletKeyStructures(unittest.TestCase):
         w = HDWallet.create(
             "strange_key_path", keys=[HDKey(), HDKey()], purpose=100,
             key_path="m/purpose'/cosigner_index/change/address_index",
-            databasefile=DATABASEFILE_UNITTESTS)
+            db_uri=self.DATABASE_URI)
         self.assertEqual(w.new_key().path, "m/100'/0/0/0")
         self.assertEqual(w.new_key_change().path, "m/100'/0/1/0")
 
@@ -1903,7 +1968,7 @@ class TestWalletKeyStructures(unittest.TestCase):
         w = HDWallet.create(
             "long_key_path", keys=[wif1, wif2], witness_type='segwit', cosigner_id=1,
             key_path="m/purpose'/coin_type'/account'/script_type'/cosigner_index/change/address_index",
-            databasefile=DATABASEFILE_UNITTESTS)
+            db_uri=self.DATABASE_URI)
         self.assertEqual(w.new_key().path, "M/1/0/0")
         self.assertEqual(w.new_key_change().path, "M/1/1/0")
         self.assertEqual(w.public_master()[0].wif, wif1)
@@ -1914,15 +1979,16 @@ class TestWalletKeyStructures(unittest.TestCase):
         self.assertRaisesRegexp(WalletError, 'Could not parse path. Index is empty.', normalize_path, "m/44h/0p/100H//1201")
 
 
-class TestWalletReadonlyAddress(unittest.TestCase):
+@parameterized_class(*params)
+class TestWalletReadonlyAddress(TestWalletMixin, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        db_remove()
+        cls.db_remove()
 
     def test_wallet_readonly_create_and_import(self):
         k = '13A1W4jLPP75pzvn2qJ5KyyqG3qPSpb9jM'
-        w = wallet_create_or_open('addrwlt', k, databasefile=DATABASEFILE_UNITTESTS)
+        w = wallet_create_or_open('addrwlt', k, db_uri=self.DATABASE_URI)
         addr = Address.import_address('13CiNuEMKASJBvGdupqaoRs2MqDNhAqmce')
         w.import_key(addr)
         self.assertEqual(len(w.accounts()), 1)
@@ -1936,7 +2002,7 @@ class TestWalletReadonlyAddress(unittest.TestCase):
         wif = 'xpub661MyMwAqRbcFCwFkcko75u2VEinbG1u5U4nq8AFJq4AbLPEvwcmhZGgGcnDcEBpcfAFEP8vVhbJJvX1ieGWdoaa5AnHfyB' \
               'DAY95TfYH6H6'
         address = '1EJiPa66sT4PCDCFnc7oRnpWebAogPqppr'
-        w = HDWallet.create('test_wallet_address_import_public_key', address, databasefile=DATABASEFILE_UNITTESTS)
+        w = HDWallet.create('test_wallet_address_import_public_key', address, db_uri=self.DATABASE_URI)
         self.assertEqual(w.addresslist(), [address])
         self.assertIsNone(w.main_key.key_public)
         w.import_key(wif)
@@ -1946,7 +2012,7 @@ class TestWalletReadonlyAddress(unittest.TestCase):
         address = 'bc1q84xq6lrzr09t3h2pw5ys5zee7rn3mxh5v65732'
         wif = 'zprvAWgYBBk7JR8Gj9CNFRBUq3DvNHDbZhH4L6AybFSTCH7DDW6boPyiQfTigAPhJma5wC4TP1o53Gz1XLh94xD3dVQUpsFDaCb2' \
               '9XmDQKBwKhz'
-        w = HDWallet.create('test_wallet_address_import_public_key_segwit', address, databasefile=DATABASEFILE_UNITTESTS)
+        w = HDWallet.create('test_wallet_address_import_public_key_segwit', address, db_uri=self.DATABASE_URI)
         self.assertEqual(w.addresslist(), [address])
         self.assertIsNone(w.main_key.wif)
         w.import_key(wif)
@@ -1956,7 +2022,7 @@ class TestWalletReadonlyAddress(unittest.TestCase):
         wif = 'xprv9s21ZrQH143K2irnebDnjwxHwCtJBoJ3iF9C2jkdkVXBiY46PQJX9kxCRMVcM1YXLERWUiUBoxQEUDqFAKbrTaL9FB4HfRY' \
               'jsGgCGpRPWTy'
         address = '1EJiPa66sT4PCDCFnc7oRnpWebAogPqppr'
-        w = HDWallet.create('test_wallet_address_import_private_key', address, databasefile=DATABASEFILE_UNITTESTS)
+        w = HDWallet.create('test_wallet_address_import_private_key', address, db_uri=self.DATABASE_URI)
         self.assertListEqual(w.addresslist(), [address])
         self.assertFalse(w.main_key.is_private)
         w.import_key(wif)

--- a/updatedb.py
+++ b/updatedb.py
@@ -27,7 +27,7 @@ except NameError:
 
 def parse_args():
     parser = argparse.ArgumentParser(description='BitcoinLib Database update script')
-    parser.add_argument('--database', '-d', default=DEFAULT_DATABASE,
+    parser.add_argument('--database', '-d', default='sqlite:///' + DEFAULT_DATABASE,
                         help="Name of specific database file to use",)
     pa = parser.parse_args()
     return pa


### PR DESCRIPTION
This PR adds support for PostgreSQL databases (and potentially others like MySQL). ~~I couldn't manage to run tests on Windows since now python 3.8 is available under the "python3" formula, which seems to break some things.~~ -> Tests are passing on Windows now too!

Several data types had to be changed, mainly due to the fact that SQLite ignores VARCHAR's length with its TEXT type, and `Integer` cannot be transformed into `BigInteger` since it's still too small, so `Numeric(25, 0)` (25 digits with zero decimals) has been used instead.

~~Lastly, not all tests are passing in my machine, but they weren't even in the original `master` branch, so I was expecting some help in that regard. However, all tests in `tests/test_wallets.py` pass.~~

I also included a fix in `bitcoind` that I found while using the library.

**EDIT:**

I also added an extra commit to support MySQL!