### PR TITLE
Add DashdClient.getutxos

### DIFF
--- a/bitcoinlib/data/providers.json
+++ b/bitcoinlib/data/providers.json
@@ -175,6 +175,28 @@
     "denominator": 100000000,
     "network_overrides": {"prefix_address_p2sh": "32"}
   },
+    "dashd": {
+    "provider": "dashd",
+    "network": "dash",
+    "client_class": "DashdClient",
+    "url": "",
+    "provider_coin_id": "",
+    "api_key": "",
+    "priority": 20,
+    "denominator": 100000000,
+    "network_overrides": null
+  },
+    "dashd.testnet": {
+    "provider": "dashd",
+    "network": "dash_testnet",
+    "client_class": "DashdClient",
+    "url": "",
+    "provider_coin_id": "",
+    "api_key": "",
+    "priority": 20,
+    "denominator": 100000000,
+    "network_overrides": null
+  },
   "cryptoid.dash": {
     "provider": "cryptoid",
     "network": "dash",

--- a/bitcoinlib/services/dashd.py
+++ b/bitcoinlib/services/dashd.py
@@ -163,7 +163,7 @@ class DashdClient(BaseClient):
             'txid': res,
             'response_dict': res
         }
-    
+
     def estimatefee(self, blocks):
         try:
             res = self.proxy.estimatesmartfee(blocks)['feerate']
@@ -173,6 +173,26 @@ class DashdClient(BaseClient):
 
     def blockcount(self):
         return self.proxy.getblockcount()
+
+    def getutxos(self, address, after_txid='', max_txs=MAX_TRANSACTIONS):
+        txs = []
+
+        for t in self.proxy.listunspent(0, 99999999, [address]):
+            txs.append({
+                'address': t['address'],
+                'tx_hash': t['txid'],
+                'confirmations': t['confirmations'],
+                'output_n': t['vout'],
+                'input_n': -1,
+                'block_height': None,
+                'fee': None,
+                'size': 0,
+                'value': int(t['amount'] * self.units),
+                'script': t['scriptPubKey'],
+                'date': None,
+            })
+
+        return txs
 
 if __name__ == '__main__':
     #


### PR DESCRIPTION
This PR adds the `getutxos` method similarly to `LitecoindClient` and `BitcoindClient`. Note Dash RPC does not provide the `getaddressinfo` endpoint, so this check has been skipped.

It also adds the corresponding section in the `providers.json` file.