### PR TITLE
Allowing multi-thread/asyncio access to bitcoinlib

### DIFF
--- a/bitcoinlib/config/config.ini.example
+++ b/bitcoinlib/config/config.ini.example
@@ -28,6 +28,9 @@
 # Location of wordlists for Mnemonic passphrases. Relative to installation directory
 ;wordlist_dir=wordlist
 
+# Allow database threads in SQLite databases
+;allow_database_threads=True
+
 [common]
 # Time for request to service providers in seconds
 ;timeout_requests=5

--- a/bitcoinlib/config/config.py
+++ b/bitcoinlib/config/config.py
@@ -48,6 +48,7 @@ BCL_DATA_DIR = ''
 BCL_WORDLIST_DIR = ''
 BCL_CONFIG_FILE = ''
 
+ALLOW_DATABASE_THREADS = None
 
 # Services
 TIMEOUT_REQUESTS = 10
@@ -199,7 +200,7 @@ def read_config():
             return fallback
 
     global BCL_INSTALL_DIR, BCL_DATABASE_DIR, DEFAULT_DATABASE, BCL_LOG_DIR, BCL_CONFIG_DIR, BCL_CONFIG_FILE
-    global BCL_DATA_DIR, BCL_WORDLIST_DIR
+    global BCL_DATA_DIR, BCL_WORDLIST_DIR, ALLOW_DATABASE_THREADS
     global TIMEOUT_REQUESTS, DEFAULT_LANGUAGE, DEFAULT_NETWORK, LOGLEVEL, DEFAULT_WITNESS_TYPE
     global UNITTESTS_FULL_DATABASE_TEST
 
@@ -250,6 +251,8 @@ def read_config():
     DEFAULT_WITNESS_TYPE = config_get('common', 'default_witness_type', fallback=DEFAULT_WITNESS_TYPE)
 
     LOGLEVEL = config_get('logs', 'loglevel', fallback=LOGLEVEL)
+    
+    ALLOW_DATABASE_THREADS = config_get("locations", "allow_database_threads", fallback=True)
 
     full_db_test = os.environ.get('UNITTESTS_FULL_DATABASE_TEST')
     if full_db_test:

--- a/bitcoinlib/db.py
+++ b/bitcoinlib/db.py
@@ -52,6 +52,10 @@ class DbInit:
         o = urlparse(db_uri)
         if not o.scheme:
             db_uri = 'sqlite:///%s' % db_uri
+        if db_uri.startswith("sqlite://") and ALLOW_DATABASE_THREADS:
+            if "?" in db_uri: db_uri += "&"
+            else: db_uri += "?"
+            db_uri += "check_same_thread=False"
         self.engine = create_engine(db_uri, isolation_level='READ UNCOMMITTED')
         Session = sessionmaker(bind=self.engine)
 


### PR DESCRIPTION
I added a configuration option which allows the SQLite database to be accessed from different threads than the main thread it was created on. This is especially useful for servers (like Quart or Flask) and due to the Python GIL not very dangereous. There's a new configuration option called "allow_database_threads" (which is only respected with "sqlite://" db uris) under the "locations" section right below the database locations.

Hope you'll approve the pull request soon. Best regards
~ Fame Castle WebDev ( https://fame.casa )