### PR TITLE
[FIX] Fix logging not appearing in console

### DIFF
--- a/bitcoinlib/main.py
+++ b/bitcoinlib/main.py
@@ -25,7 +25,7 @@ from bitcoinlib.config.config import *
 
 
 # Initialize logging
-logger = logging.getLogger()
+logger = logging.getLogger('bitcoinlib')
 logger.setLevel(LOGLEVEL)
 
 if ENABLE_BITCOINLIB_LOGGING:


### PR DESCRIPTION
`logging.getLogger()` gets root logger and manipulates it. In case this is a library, it's better to get its own logger using `logging.getLogger('bitcoinlib')`