### PR TITLE
Update scrypt version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ install_requires = [
       'fastecdsa==2.1.5;platform_system!="Windows"',
       'ecdsa==0.16;platform_system=="Windows"',
       'pyaes==1.6.1',
-      'scrypt==0.8.17',
+      'scrypt==0.8.18',
       'SQLAlchemy==1.3.22',
       'numpy==1.19.5',
 ]


### PR DESCRIPTION
`scrypt` version 0.8.17 doesn't provide windows python 3.9 pre-build package. Update to 0.8.17.