### PR TITLE
fix duplicate checks in litecoind from_config

### DIFF
--- a/bitcoinlib/services/litecoind.py
+++ b/bitcoinlib/services/litecoind.py
@@ -81,13 +81,7 @@ class LitecoindClient(BaseClient):
                     break
         else:
             cfn = Path(BCL_DATA_DIR, 'config', configfile)
-        if not cfn or not cfn.is_file():
-            raise ConfigError(
-                "Config file %s not found. Please install Litecoin client and specify a path to config "
-                "file if path is not default. Or place a config file in .bitcoinlib/litecoin.conf to "
-                "reference to an external server." % cfn)
-        else:
-            cfn = Path(BCL_DATA_DIR, 'config', configfile)
+
         if not cfn or not cfn.is_file():
             raise ConfigError("Config file %s not found. Please install Litecoin client and specify a path to config "
                               "file if path is not default. Or place a config file in .bitcoinlib/litecoin.conf to "


### PR DESCRIPTION
The method ``from_config`` was  a bit faulty (probably due to a copy-past).
When loading an instance from a config file without providing the ``configfile`` the variable ``cfn`` is properly set, but an additional else case (line 90) was causing a TypeError, because ``Path(BCL_DATA_DIR, 'config', configfile)`` was concating a path with ``configfile`` which is ``None``.

The check can be removed as it is already done. *(bitcoind.py implements it correctly)*.