### PR TITLE
Change from Thai Baht symbol to BTC Symbol

### DIFF
--- a/bitcoinlib/data/networks.json
+++ b/bitcoinlib/data/networks.json
@@ -37,7 +37,7 @@
     "description": "Bitcoin",
     "currency_name": "bitcoin",
     "currency_name_plural": "bitcoins",
-    "currency_symbol": "฿",
+    "currency_symbol": "₿",
     "currency_code": "BTC",
     "prefix_address": "00",
     "prefix_address_p2sh": "05",

--- a/bitcoinlib/values.py
+++ b/bitcoinlib/values.py
@@ -295,7 +295,7 @@ class Value:
         '2.10000000 GBTC'
 
         >>> Value('1.5 BTC').str(currency_repr='symbol')
-        '1.50000000 ฿'
+        '1.50000000 ₿'
 
         >>> Value('1.5 BTC').str(currency_repr='name')
         '1.50000000 bitcoins'
@@ -304,7 +304,7 @@ class Value:
         :type denominator: int, float, str
         :param decimals: Number of decimals to use
         :type decimals: float
-        :param currency_repr: Representation of currency. I.e. code: BTC, name: bitcoins, symbol: ฿
+        :param currency_repr: Representation of currency. I.e. code: BTC, name: bitcoins, symbol: ₿
         :type currency_repr: str
 
         :return str:
@@ -359,7 +359,7 @@ class Value:
 
         :param decimals: Number of decimals to use
         :type decimals: float
-        :param currency_repr: Representation of currency. I.e. code: BTC, name: Bitcoin, symbol: ฿
+        :param currency_repr: Representation of currency. I.e. code: BTC, name: Bitcoin, symbol: ₿
         :type currency_repr: str
         :return str:
         """
@@ -377,7 +377,7 @@ class Value:
 
         :param decimals: Number of decimals to use
         :type decimals: float
-        :param currency_repr: Representation of currency. I.e. code: BTC, name: Bitcoin, symbol: ฿
+        :param currency_repr: Representation of currency. I.e. code: BTC, name: Bitcoin, symbol: ₿
         :type currency_repr: str
         :return str:
         """

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -32,7 +32,7 @@ class TestNetworks(unittest.TestCase):
         network = Network('dash')
         self.assertEqual(network.print_value(10000), '0.00010000 DASH')
 
-        self.assertEqual(print_value(123, rep='symbol', denominator=0.001), '0.00123 m฿')
+        self.assertEqual(print_value(123, rep='symbol', denominator=0.001), '0.00123 m₿')
         self.assertEqual(print_value(123, denominator=1e-6), '1.23 µBTC')
         self.assertEqual(print_value(1e+14, network='dogecoin', denominator=1e+6, decimals=0), '1 MDOGE')
         self.assertEqual(print_value(1200, denominator=1e-8, rep='Satoshi'), '1200 Satoshi')


### PR DESCRIPTION
Re: Issue #193

Updated currency symbol from Thai Baht (&#xe3f;) to Unicode BTC symbol (&#x20bf;). 