### PR TITLE
Dogecoin -  api support

### DIFF
--- a/bitcoinlib/data/providers.json
+++ b/bitcoinlib/data/providers.json
@@ -400,7 +400,7 @@
     "provider": "dogecoind",
     "network": "dogecoin",
     "client_class": "DogecoindClient",
-    "provider_coin_id": "",
+    "provider_coin_id": "DOGE",
     "url": "",
     "api_key": "",
     "priority": 20,

--- a/bitcoinlib/services/authproxy.py
+++ b/bitcoinlib/services/authproxy.py
@@ -149,7 +149,9 @@ class AuthServiceProxy(object):
                 'Authorization': self.__auth_header,
                 'Content-type': 'application/json'
             }
-        self.__conn.request('POST', self.__url.path, postdata, headers)
+
+        url_path = self.__url.path.split(':')[0]
+        self.__conn.request('POST', url_path, postdata, headers)
         self.__conn.sock.settimeout(self.__timeout)
 
         response = self._get_response()

--- a/bitcoinlib/services/authproxy.py
+++ b/bitcoinlib/services/authproxy.py
@@ -149,9 +149,7 @@ class AuthServiceProxy(object):
                 'Authorization': self.__auth_header,
                 'Content-type': 'application/json'
             }
-
-        url_path = self.__url.path.split(':')[0]
-        self.__conn.request('POST', url_path, postdata, headers)
+        self.__conn.request('POST', self.__url.path, postdata, headers)
         self.__conn.sock.settimeout(self.__timeout)
 
         response = self._get_response()

--- a/bitcoinlib/services/dogecoind.py
+++ b/bitcoinlib/services/dogecoind.py
@@ -115,7 +115,7 @@ class DogecoindClient(BaseClient):
         url = "http://%s:%s@%s:%s" % (config.get('rpc', 'rpcuser'), config.get('rpc', 'rpcpassword'), server, port)
         return DogecoindClient(network, url)
 
-    def __init__(self, network='dogecoin', base_url='', denominator=100000000, *args):
+    def __init__(self, network='dogecoin', base_url='', denominator=100000000, api_key='', *args):
         """
         Open connection to dogecoin node
 
@@ -132,16 +132,21 @@ class DogecoindClient(BaseClient):
             bdc = self.from_config('', network)
             base_url = bdc.base_url
             network = bdc.network
-        if len(base_url.split(':')) != 4:
-            raise ConfigError("Dogecoind connection URL must be of format 'http(s)://user:password@host:port,"
-                              "current format is %s. Please set url in providers.json file or check dogecoin config "
-                              "file" % base_url)
-        if 'password' in base_url:
-            raise ConfigError("Invalid password in dogecoind provider settings. "
-                              "Please replace default password and set url in providers.json or dogecoin.conf file")
+
+        if not api_key:
+            if len(base_url.split(':')) != 4:
+                raise ConfigError("Dogecoind connection URL must be of format 'http(s)://user:password@host:port,"
+                                  "current format is %s. Please set url in providers.json file or check dogecoin config "
+                                  "file" % base_url)
+            if 'password' in base_url:
+                raise ConfigError("Invalid password in dogecoind provider settings. "
+                                  "Please replace default password and set url in providers.json or dogecoin.conf file")
+
         _logger.info("Connect to dogecoind")
-        self.proxy = AuthServiceProxy(base_url)
-        super(self.__class__, self).__init__(network, PROVIDERNAME, base_url, denominator, *args)
+        self.proxy = AuthServiceProxy(base_url, api_key)
+        super(self.__class__, self).__init__(network, PROVIDERNAME, base_url, denominator, api_key, *args)
+
+
 
     def getutxos(self, address, after_txid='', max_txs=MAX_TRANSACTIONS):
         txs = []

--- a/bitcoinlib/services/dogecoind.py
+++ b/bitcoinlib/services/dogecoind.py
@@ -105,8 +105,7 @@ class DogecoindClient(BaseClient):
         if network == 'testnet':
             port = 44555
         else:
-            # port = 22555
-            port = 443
+            port = 22555
         port = _read_from_config(config, 'rpc', 'rpcport', port)
         server = '127.0.0.1'
         server = _read_from_config(config, 'rpc', 'rpcconnect', server)

--- a/bitcoinlib/services/dogecoind.py
+++ b/bitcoinlib/services/dogecoind.py
@@ -105,7 +105,8 @@ class DogecoindClient(BaseClient):
         if network == 'testnet':
             port = 44555
         else:
-            port = 22555
+            # port = 22555
+            port = 443
         port = _read_from_config(config, 'rpc', 'rpcport', port)
         server = '127.0.0.1'
         server = _read_from_config(config, 'rpc', 'rpcconnect', server)


### PR DESCRIPTION
1. Dogecoin and AuthProxy only support nodes with username and passwords. Nodes with API-KEY are not supported.
2. Irrespective of the scheme, AuthProxy sets port to 80 by default. When scheme of server url is https, it should be 443.

This PR fixes these 2 issues.