### PR TITLE
AuthServiceProxy.batch_ request bugfix

### DIFF
--- a/bitcoinlib/services/authproxy.py
+++ b/bitcoinlib/services/authproxy.py
@@ -168,7 +168,7 @@ class AuthServiceProxy(object):
         results = []
         responses = self._get_response()
         for response in responses:
-            if 'error' in response:
+            if response.get('error') is not None:
                 raise JSONRPCException(response['error'])
             elif 'result' not in response:
                 raise JSONRPCException({

--- a/bitcoinlib/services/authproxy.py
+++ b/bitcoinlib/services/authproxy.py
@@ -168,7 +168,7 @@ class AuthServiceProxy(object):
         results = []
         responses = self._get_response()
         for response in responses:
-            if response['error'] is not None:
+            if 'error' in response:
                 raise JSONRPCException(response['error'])
             elif 'result' not in response:
                 raise JSONRPCException({


### PR DESCRIPTION
The `batch_` method of the `AuthServiceProxy` class has a bug (same bug also exists in the python-bitcoinrpc package) where it will always crash with `KeyError 'error'` because it tries to explicitly check `response["error"] is not None` which fails when there is no error in the response. Instead, when the request is successful, it will not contain the `'error'` key, in this case the more sane approach is to check for its existence first.