### PR TITLE
Optimize provider lookup with `set` Instead of `list`

### DIFF
--- a/bitcoinlib/services/services.py
+++ b/bitcoinlib/services/services.py
@@ -101,7 +101,7 @@ class Service(object):
             raise ServiceError(errstr)
         f.close()
 
-        provider_list = list(set([self.providers_defined[x]['provider'] for x in self.providers_defined]))
+        provider_set = {self.providers_defined[x]['provider'] for x in self.providers_defined}
         if providers is None:
             providers = []
         if exclude_providers is None:
@@ -109,7 +109,7 @@ class Service(object):
         if not isinstance(providers, list):
             providers = [providers]
         for p in providers:
-            if p not in provider_list:
+            if p not in provider_set:
                 raise ServiceError("Provider '%s' not found in provider definitions" % p)
 
         self.providers = {}


### PR DESCRIPTION
## Description
This PR refactors the provider lookup logic by replacing `provider_list` (previously a `list` from `set`) with `provider_set` (now just `set`). The change improves the efficiency of membership checks (`p not in provider_set`) and makes the code slightly more readable and intentional.

## Why This Change?
The original code used a `list` to store unique providers and checked membership with `if p not in provider_list`. While this worked fine, lookups in a `list` have a time complexity of **O(n)**, meaning the operation scales linearly with the number of providers. By switching to a `set`, we reduce this to **O(1)** on average, which is a constant-time lookup—much faster, especially as the number of providers grows.

Granted, in most cases, the provider list might not be large enough for this to cause a dramatic performance boost. However, even for small datasets, this change:
- **Makes sense conceptually**: Sets are designed for fast membership testing, aligning perfectly with our use case.
- **Future-proofs the code**: If the provider list grows over time, we won’t need to revisit this optimization later.
- **Improves readability**: Using a `set` clearly signals that we only care about uniqueness and membership, not order or indexing.

## No Logic Changes
The core logic remains unchanged:
- We still collect all providers from `self.providers_defined`.
- We still raise a `ServiceError` if a provider isn’t found.
- The behavior is identical; only the data structure differs.