### PR TITLE
Send server.version as first message to interact with Electrumx server

### DIFF
--- a/bitcoinlib/services/electrumx.py
+++ b/bitcoinlib/services/electrumx.py
@@ -34,7 +34,7 @@ from bitcoinlib.keys import Address, sha256
 from bitcoinlib.scripts import Script
 
 PROVIDERNAME = 'electrumx'
-
+ELECTRUMX_PROTOCOL_VERSION = "1.6"
 
 _logger = logging.getLogger(__name__)
 
@@ -65,6 +65,7 @@ class ElectrumxClient(BaseClient):
             async def main(host, port, method, parameters):
                 async with aiorpcx.connect_rs(host, port, framer=aiorpcx.NewlineFramer(5000000)) as session:
                     session.sent_request_timeout = self.timeout
+                    await session.send_request('server.version', ["Bitcoinlib", ELECTRUMX_PROTOCOL_VERSION])
                     return await session.send_request(method, parameters)
 
             loop = asyncio.get_event_loop()
@@ -81,6 +82,20 @@ class ElectrumxClient(BaseClient):
             sock.connect((host, int(port)))
             import json
             from time import sleep
+            server_version_msg = {"method": "server.version", "params": ["BitcoinLib", ELECTRUMX_PROTOCOL_VERSION], "id": 0}
+            sock.sendall(json.dumps(server_version_msg).encode('utf-8') + b'\n')
+            sleep(0.1)
+            buffer = b""
+            try:
+                sock.settimeout(1)
+                while True:
+                    data = sock.recv(4096)
+                    if not data:
+                        break
+                    buffer += data
+            except socket.timeout:
+                pass
+            sock.settimeout(10)
             sock.sendall(json.dumps(content).encode('utf-8')+b'\n')
             sleep(0.5)
             sock.shutdown(socket.SHUT_WR)


### PR DESCRIPTION
We are using bitcoinlib for our project.

I had installed up a bitcoin-core node + electrumx server, locally in regtest mode.
I had configured bitcoinlib's provider.json to connect to the electrumx server

However, when executing wallet.scan(), bitcoinlib would throw an error:

```bash
2026/04/17 17:39:18 DEBUG _provider_execute(221) Error Extra data: line 2 column 1 (char 1024) on provider bitcoin.electrumx
2026/04/17 17:39:18 ERROR __init__(40) No successful response from any serviceprovider: ['bitcoin.electrumx']
```

The electrumx server complained:

```bash
INFO:ElectrumX:[3] TCP 172.20.0.12:42954, 1 total
INFO:ElectrumX:[3] closing session: server.version must be first msg. got: blockchain.headers.subscribe
```

After reading the protocol docs (https://electrumx.readthedocs.io/en/latest/protocol-methods.html#server-version) it became clear the electrumx provider in bitcoinlib wasn't sending this required message.

I could see the second message being crafted:

```bash
# bitcoinlib/services/electrumx.py
    def blockcount(self):
        return self.compose_request('blockchain.headers.subscribe')['height']
```

I realized that before sending blockcount() or other methods, the server.version message should be sent. But I wasn't completely sure how to implement this. As a last resort I shared the codebase with an AI model from Mistral, and asked for help. The result is this PR.

I am happy because now electrumx responds the way I expect it to:

```bash
2026/04/17 17:45:51 DEBUG _provider_execute(210) Executed method blockcount from provider bitcoin.electrumx
2026/04/17 17:45:51 DEBUG _provider_execute(210) Executed method getutxos from provider bitcoin.electrumx
2026/04/17 17:45:51 INFO utxos_update(3323) Got 0 new UTXOs for account 0
2026/04/17 17:45:52 INFO _balance_update(3152) Got balance for 10 key(s)
```

**Now**, if there is feedback on the implementation it is certainly welcome! But hopefully this can get merged :slightly_smiling_face: 